### PR TITLE
Updated the express api to only listen on localhost

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tidal-hifi",
-  "version": "0.1.0",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/scripts/express.js
+++ b/src/scripts/express.js
@@ -53,7 +53,7 @@ expressModule.run = function(mainWindow) {
   if (store.get(settings.api)) {
     let port = store.get(settings.apiSettings.port);
 
-    expressInstance = expressApp.listen(port, () => {});
+    expressInstance = expressApp.listen(port, "127.0.0.1", () => {});
     expressInstance.on("error", function(e) {
       let message = e.code;
       if (e.code === "EADDRINUSE") {


### PR DESCRIPTION
Hey :wave:!

By default, `expressjs` listens on `0.0.0.0`/`::` ([see `net.Server`'s `server.listen([port[, host[, backlog]]][, callback])` documentation](https://nodejs.org/api/net.html#net_server_listen_port_host_backlog_callback)) and I don't feel really confident with exposing random ports allowing to control my music playback on the Internet, so I updated it to listen on `127.0.0.1` instead :wink:.

If some people depend on being to control `tidal-hifi` from their local network, maybe the address should be replaced with a `host` field in `settings.apiSettings`.

Cheers!