### PR TITLE
Fix last.fm / token callbacks

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -44,6 +44,7 @@ function createWindow(options = {}) {
       preload: path.join(__dirname, "preload.js"),
       plugins: true,
       devTools: !app.isPackaged,
+      sandbox: true, // incidentally work around Electron lack of support for window.opener; needed for popup OAuth token callbacks (e.g. last.fm) to work
     },
   });
 


### PR DESCRIPTION
Work around Electron lack of support for `window.opener` so that last.fm / token callbacks work.

See [original issue comment](https://github.com/Mastermindzh/tidal-hifi/issues/4#issuecomment-620616860) for in-depth analysis.