### PR TITLE
Add 2 new fields to MediaInfo and an addition to Discord RPC

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@mastermindzh/prettier-config": "^1.0.0",
-    "electron": "git+https://github.com/castlabs/electron-releases.git#v8.5.2-wvvmp",
+    "electron": "git+https://github.com/castlabs/electron-releases.git#v10.4.3-wvvmp",
     "electron-builder": "^21.2.0",
     "electron-reload": "^1.5.0",
     "prettier": "^2.0.4",

--- a/src/main.js
+++ b/src/main.js
@@ -44,6 +44,7 @@ function createWindow(options = {}) {
       preload: path.join(__dirname, "preload.js"),
       plugins: true,
       devTools: true, // I like tinkering, others might too
+      enableRemoteModule: true,
     },
   });
 

--- a/src/preload.js
+++ b/src/preload.js
@@ -250,7 +250,6 @@ function updateMediaInfo(options, notify) {
  */
 setInterval(function () {
   const title = elements.getText("title");
-  //const id = elements.get("url").href.replace(/[^0-9]/g, "");
   const artists = elements.getText("artists");
   const current = elements.getText("current");
   const duration = elements.getText("duration");
@@ -285,12 +284,12 @@ setInterval(function () {
     }
 
     // Video/Song check if it's a video return URL as undefined due to it not having an id.
-    switch(elements.get("url")) {
+    switch(elements.get("title").querySelector("a")) {
       case null:
         currentURL = undefined;
         break;
       default:
-        const id = elements.get("url").href.replace(/[^0-9]/g, "");
+        const id = elements.get("title").querySelector("a").href.replace(/[^0-9]/g, "");
         currentURL = `https://tidal.com/browse/track/${id}`;
         break;
     }

--- a/src/preload.js
+++ b/src/preload.js
@@ -277,30 +277,30 @@ setInterval(function () {
     currentSong = songDashArtistTitle;
     currentPlayStatus = currentStatus;
 
+    // check progress bar value and make sure current stays up to date after switch
+    if(barvalue != barval) {
+      barvalue = barval;
+      oldcurrent = options.current;
+      updatecurrent = true;
+    }
+
+    if(updatecurrent) {
+      if(options.current == oldcurrent && currentStatus != "paused") return;
+      oldcurrent = options.current;
+      updatecurrent = false;
+    }
+
     // make sure current is set to 0 if title changes
-    if (titleOrArtistChanged) {
+    if(titleOrArtistChanged) {
       options.current = "0:00";
       oldcurrent = options.current;
       barvalue = barval;
-    } else {
-      // check progress bar value and make sure current stays up to date after switch
-      if (barvalue != barval) {
-        barvalue = barval;
-        oldcurrent = options.current;
-        updatecurrent = true;
-      }
+    }
 
-      if (updatecurrent) {
-        if (options.current == oldcurrent && currentStatus != "paused") return;
-        oldcurrent = options.current;
-        updatecurrent = false;
-      }
-
-      if (durationChanged) {
-        options.duration = duration;
-        options.current = current;
-        sduration = duration;
-      }
+    if(durationChanged) {
+      options.duration = duration;
+      options.current = current;
+      sduration = duration;
     }
 
     const image = elements.getSongIcon();

--- a/src/preload.js
+++ b/src/preload.js
@@ -276,7 +276,7 @@ setInterval(function () {
     currentPlayStatus = currentStatus;
 
     // check progress bar value and make sure current stays up to date after switch
-    if(barvalue != barval) {
+    if(barvalue != barval && !titleOrArtistChanged) {
       barvalue = barval;
       oldcurrent = options.current;
       options.duration = duration;

--- a/src/preload.js
+++ b/src/preload.js
@@ -12,7 +12,6 @@ const notificationPath = `${app.getPath("userData")}/notification.jpg`;
 let currentSong = "";
 let player;
 let currentPlayStatus = statuses.paused;
-let sduration;
 let barvalue;
 let updatecurrent = false;
 let oldcurrent;
@@ -267,11 +266,10 @@ setInterval(function () {
   };
 
   const playStatusChanged = currentStatus !== currentPlayStatus;
-  const durationChanged = duration !== sduration;
   const barvalChanged = barval !== barvalue;
   const titleOrArtistChanged = currentSong !== songDashArtistTitle;
 
-  if (titleOrArtistChanged || playStatusChanged || durationChanged || barvalChanged || updatecurrent) {
+  if (titleOrArtistChanged || playStatusChanged || barvalChanged || updatecurrent) {
     // update title and play info with new info
     setTitle(songDashArtistTitle);
     currentSong = songDashArtistTitle;
@@ -281,6 +279,7 @@ setInterval(function () {
     if(barvalue != barval) {
       barvalue = barval;
       oldcurrent = options.current;
+      options.duration = duration;
       updatecurrent = true;
     }
 
@@ -295,12 +294,6 @@ setInterval(function () {
       options.current = "0:00";
       oldcurrent = options.current;
       barvalue = barval;
-    }
-
-    if(durationChanged) {
-      options.duration = duration;
-      options.current = current;
-      sduration = duration;
     }
 
     const image = elements.getSongIcon();

--- a/src/preload.js
+++ b/src/preload.js
@@ -15,6 +15,7 @@ let currentPlayStatus = statuses.paused;
 let barvalue;
 let updatecurrent = false;
 let oldcurrent;
+let currentURL = undefined;
 
 const elements = {
   play: '*[data-test="play"]',
@@ -22,7 +23,7 @@ const elements = {
   next: '*[data-test="next"]',
   previous: 'button[data-test="previous"]',
   title: '*[data-test^="footer-track-title"]',
-  artists: '*[data-test^="grid-item-detail-text-title-artist"]',
+  artists: '*[class^="elemental__text elemental__text css-oxcos"]',
   home: '*[data-test="menu--home"]',
   back: '[class^="backwardButton"]',
   forward: '[class^="forwardButton"]',
@@ -249,7 +250,7 @@ function updateMediaInfo(options, notify) {
  */
 setInterval(function () {
   const title = elements.getText("title");
-  const url = elements.get("url").href.replace(/[^0-9]/g, "");
+  //const id = elements.get("url").href.replace(/[^0-9]/g, "");
   const artists = elements.getText("artists");
   const current = elements.getText("current");
   const duration = elements.getText("duration");
@@ -260,7 +261,7 @@ setInterval(function () {
     title,
     message: artists,
     status: currentStatus,
-    url: `https://tidal.com/browse/track/${url}`,
+    url: currentURL,
     current: current,
     duration: duration,
   };
@@ -281,6 +282,17 @@ setInterval(function () {
       oldcurrent = options.current;
       options.duration = duration;
       updatecurrent = true;
+    }
+
+    // Video/Song check if it's a video return URL as undefined due to it not having an id.
+    switch(elements.get("url")) {
+      case null:
+        currentURL = undefined;
+        break;
+      default:
+        const id = elements.get("url").href.replace(/[^0-9]/g, "");
+        currentURL = `https://tidal.com/browse/track/${id}`;
+        break;
     }
 
     if(updatecurrent) {

--- a/src/preload.js
+++ b/src/preload.js
@@ -35,7 +35,6 @@ const elements = {
   settings: '*[data-test^="open-settings"]',
   media: '*[data-test="current-media-imagery"]',
   image: "img",
-  url: 'a[href*="/track/"]',
   current: '*[data-test="current-time"]',
   duration: '*[data-test="duration-time"]',
   bar: '*[data-test="progress-bar"]',

--- a/src/preload.js
+++ b/src/preload.js
@@ -277,29 +277,30 @@ setInterval(function () {
     currentSong = songDashArtistTitle;
     currentPlayStatus = currentStatus;
 
-    // check progress bar value and make sure current stays up to date after switch
-    if(barvalue != barval) {
-      barvalue = barval;
-      oldcurrent = options.current;
-      updatecurrent = true;
-    }
-
-    if(updatecurrent) {
-      if(options.current == oldcurrent && currentStatus != "paused") return;
-      oldcurrent = options.current;
-      updatecurrent = false;
-    }
-
     // make sure current is set to 0 if title changes
-    if(titleOrArtistChanged) {
+    if (titleOrArtistChanged) {
       options.current = "0:00";
+      oldcurrent = options.current;
       barvalue = barval;
-    }
+    } else {
+      // check progress bar value and make sure current stays up to date after switch
+      if (barvalue != barval) {
+        barvalue = barval;
+        oldcurrent = options.current;
+        updatecurrent = true;
+      }
 
-    if(durationChanged) {
-      options.duration = duration;
-      options.current = current;
-      sduration = duration;
+      if (updatecurrent) {
+        if (options.current == oldcurrent && currentStatus != "paused") return;
+        oldcurrent = options.current;
+        updatecurrent = false;
+      }
+
+      if (durationChanged) {
+        options.duration = duration;
+        options.current = current;
+        sduration = duration;
+      }
     }
 
     const image = elements.getSongIcon();

--- a/src/scripts/discord.js
+++ b/src/scripts/discord.js
@@ -1,21 +1,33 @@
 const discordrpc = require("discord-rpc");
-const { ipcMain } = require("electron");
-const electron = require("electron");
+const { app, ipcMain } = require("electron");
 const globalEvents = require("../constants/globalEvents");
 const clientId = "833617820704440341";
 const mediaInfoModule = require("./mediaInfo");
 const discordModule = [];
+
+function timeToSeconds(timeArray) {
+  let minutes = (timeArray[0] * 1);
+  let seconds = (minutes * 60) + (timeArray[1] * 1);
+  return seconds;
+}
 
 let rpc;
 const observer = (event, arg) => {
   if (mediaInfoModule.mediaInfo.status == "paused" && rpc) {
     rpc.setActivity(idleStatus);
   } else if (rpc) {
+    let csec = timeToSeconds(mediaInfoModule.mediaInfo.current.split(":"));
+    let dsec = timeToSeconds(mediaInfoModule.mediaInfo.duration.split(":"));
+    const date = new Date();
+    let now = date.getTime() / 1000 | 0;
+    let remaining = date.setSeconds(date.getSeconds() + (dsec - csec));
     rpc.setActivity({
       ...idleStatus,
       ...{
         details: `Listening to ${mediaInfoModule.mediaInfo.title}`,
         state: mediaInfoModule.mediaInfo.artist,
+        startTimestamp: parseInt(now),
+        endTimestamp: parseInt(remaining),
         buttons: [{ label: "Play on Tidal", url: mediaInfoModule.mediaInfo.url }],
       },
     });
@@ -25,7 +37,7 @@ const observer = (event, arg) => {
 const idleStatus = {
   details: `Browsing Tidal`,
   largeImageKey: "tidal-hifi-icon",
-  largeImageText: `Tidal HiFi ${electron.app.getVersion()}`,
+  largeImageText: `Tidal HiFi ${app.getVersion()}`,
   instance: false,
 };
 

--- a/src/scripts/discord.js
+++ b/src/scripts/discord.js
@@ -16,11 +16,11 @@ const observer = (event, arg) => {
   if (mediaInfoModule.mediaInfo.status == "paused" && rpc) {
     rpc.setActivity(idleStatus);
   } else if (rpc) {
-    let csec = timeToSeconds(mediaInfoModule.mediaInfo.current.split(":"));
-    let dsec = timeToSeconds(mediaInfoModule.mediaInfo.duration.split(":"));
+    const currentSeconds = timeToSeconds(mediaInfoModule.mediaInfo.current.split(":"));
+    const durationSeconds = timeToSeconds(mediaInfoModule.mediaInfo.duration.split(":"));
     const date = new Date();
-    let now = date.getTime() / 1000 | 0;
-    let remaining = date.setSeconds(date.getSeconds() + (dsec - csec));
+    const now = date.getTime() / 1000 | 0;
+    const remaining = date.setSeconds(date.getSeconds() + (durationSeconds - currentSeconds));
     if (mediaInfoModule.mediaInfo.url) {
       rpc.setActivity({
         ...idleStatus,

--- a/src/scripts/discord.js
+++ b/src/scripts/discord.js
@@ -21,16 +21,28 @@ const observer = (event, arg) => {
     const date = new Date();
     let now = date.getTime() / 1000 | 0;
     let remaining = date.setSeconds(date.getSeconds() + (dsec - csec));
-    rpc.setActivity({
-      ...idleStatus,
-      ...{
-        details: `Listening to ${mediaInfoModule.mediaInfo.title}`,
-        state: mediaInfoModule.mediaInfo.artist,
-        startTimestamp: parseInt(now),
-        endTimestamp: parseInt(remaining),
-        buttons: [{ label: "Play on Tidal", url: mediaInfoModule.mediaInfo.url }],
-      },
-    });
+    if (mediaInfoModule.mediaInfo.url) {
+      rpc.setActivity({
+        ...idleStatus,
+        ...{
+          details: `Listening to ${mediaInfoModule.mediaInfo.title}`,
+          state: mediaInfoModule.mediaInfo.artist,
+          startTimestamp: parseInt(now),
+          endTimestamp: parseInt(remaining),
+          buttons: [{ label: "Play on Tidal", url: mediaInfoModule.mediaInfo.url }],
+        },
+      });
+    } else {
+      rpc.setActivity({
+        ...idleStatus,
+        ...{
+          details: `Listening to ${mediaInfoModule.mediaInfo.title}`,
+          state: mediaInfoModule.mediaInfo.artist,
+          startTimestamp: parseInt(now),
+          endTimestamp: parseInt(remaining),
+        },
+      });
+    }
   }
 };
 

--- a/src/scripts/discord.js
+++ b/src/scripts/discord.js
@@ -36,7 +36,7 @@ const observer = (event, arg) => {
       rpc.setActivity({
         ...idleStatus,
         ...{
-          details: `Listening to ${mediaInfoModule.mediaInfo.title}`,
+          details: `Watching ${mediaInfoModule.mediaInfo.title}`,
           state: mediaInfoModule.mediaInfo.artist,
           startTimestamp: parseInt(now),
           endTimestamp: parseInt(remaining),

--- a/src/scripts/mediaInfo.js
+++ b/src/scripts/mediaInfo.js
@@ -6,6 +6,8 @@ const mediaInfo = {
   icon: "",
   status: statuses.paused,
   url: "",
+  current: "",
+  duration: ""
 };
 const mediaInfoModule = {
   mediaInfo,
@@ -20,6 +22,8 @@ mediaInfoModule.update = function (arg) {
   mediaInfo.icon = propOrDefault(arg.icon);
   mediaInfo.url = propOrDefault(arg.url);
   mediaInfo.status = propOrDefault(arg.status);
+  mediaInfo.current = propOrDefault(arg.current);
+  mediaInfo.duration = propOrDefault(arg.duration);
 };
 
 /**


### PR DESCRIPTION
I have tried adding the "hh:mm:ss left" function to Discord RPC I came on the idea as applications like PreMiD use it for YouTube Music(https://premid.app/store/presences/YouTube%20Music)
Due to some small delays when skipping parts of the song I feel like it could be improved on but so far it works without issues after 3-4 hours of fixing and debugging it.

~~EDIT: I have also realized just now that when it switches songs after it ends it pops up with browsing tidal for a second while it does the checks which is one of the things that also should be improved on.~~

![image](https://user-images.githubusercontent.com/8841466/115456670-b938e200-a223-11eb-8d38-91a258c5e998.png)
