### PR TITLE
Show "Tidal Hifi" as application name for notify-send notifications

### DIFF
--- a/src/preload.js
+++ b/src/preload.js
@@ -292,6 +292,7 @@ setInterval(function () {
   const artists = elements.getArtists();
   const current = elements.getText("current");
   const duration = elements.getText("duration");
+  const appName = "Tidal Hifi";
   const progressBarcurrentTime = elements.get("bar").getAttribute("aria-valuenow");
   const songDashArtistTitle = `${title} - ${artists}`;
   const currentStatus = getCurrentlyPlayingStatus();
@@ -302,6 +303,7 @@ setInterval(function () {
     url: currentURL,
     current: current,
     duration: duration,
+    'app-name': appName,
   };
 
   const playStatusChanged = currentStatus !== currentPlayStatus;


### PR DESCRIPTION
Set the 'app-name' variable used by notify-send under Linux.

Before
![Screenshot_20211203_155705](https://user-images.githubusercontent.com/16386753/144632867-af1cc2e1-bd76-4fba-bf61-2d4e1c88e062.png)

After
![Screenshot_20211203_155513](https://user-images.githubusercontent.com/16386753/144632610-5fd8c870-4cf4-4b18-a730-c0d3a94a4ef6.png)

Closes #7 