### PR TITLE
Generate pacman builds using Github workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ jobs:
   build_on_linux:
     runs-on: ubuntu-latest
     steps:
+      - name: Install libarchive-tools
+        run: sudo apt-get install -y libarchive-tools
       - uses: actions/checkout@master
       - uses: actions/setup-node@master
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
   build_on_linux:
     runs-on: ubuntu-latest
     steps:
+      - name: Install libarchive-tools
+        run: sudo apt-get install -y libarchive-tools
       - uses: actions/checkout@master
       - uses: actions/setup-node@master
         with:

--- a/build/electron-builder.yml
+++ b/build/electron-builder.yml
@@ -10,7 +10,7 @@ snap:
 linux:
   category: Audio
   target:
-    # - pacman
+    - pacman
     - tar.gz
     - deb
     - rpm

--- a/src/preload.js
+++ b/src/preload.js
@@ -292,6 +292,7 @@ setInterval(function () {
   const artists = elements.getArtists();
   const current = elements.getText("current");
   const duration = elements.getText("duration");
+  const appName = "Tidal Hifi";
   const progressBarcurrentTime = elements.get("bar").getAttribute("aria-valuenow");
   const songDashArtistTitle = `${title} - ${artists}`;
   const currentStatus = getCurrentlyPlayingStatus();
@@ -302,6 +303,7 @@ setInterval(function () {
     url: currentURL,
     current: current,
     duration: duration,
+    'app-name': appName,
   };
 
   const playStatusChanged = currentStatus !== currentPlayStatus;


### PR DESCRIPTION
Previous builds failed due to missing `bsdtar` build dependencies when building the package using the Github workflow Linux environment.

Fully working workflow can be seen [here](https://github.com/kevihiiin/tidal-hifi/actions/runs/1555060342).
The generated `tida-hifi.pacman` file can be installed and used under Arch Linux/Manjaro.
