### PR TITLE
use higher resolution image for song/album cover

### DIFF
--- a/src/preload.js
+++ b/src/preload.js
@@ -57,7 +57,7 @@ const elements = {
     if (figure) {
       const mediaElement = figure.querySelector(this["image"]);
       if (mediaElement) {
-        return mediaElement.src.replace("80x80", "1280x1280");
+        return mediaElement.src.replace("80x80", "640x640");
       }
     }
 

--- a/src/preload.js
+++ b/src/preload.js
@@ -57,7 +57,7 @@ const elements = {
     if (figure) {
       const mediaElement = figure.querySelector(this["image"]);
       if (mediaElement) {
-        return mediaElement.src;
+        return mediaElement.src.replace("80x80", "1280x1280");
       }
     }
 


### PR DESCRIPTION
This compliments #84 as the album/song image would turn out pixelated/blurry since the default res the player uses in the image source is 80x80 instead of one of the high quality images