### PR TITLE
Get album name

### DIFF
--- a/src/preload.js
+++ b/src/preload.js
@@ -42,6 +42,7 @@ const elements = {
   album_header_title: '.header-details [data-test="title"]',
   playing_title: 'span[data-test="table-cell-title"].css-geqnfr',
   album_name_cell: '[data-test="table-cell-album"]',
+  tracklist_row: '[data-test="tracklist-row"]',
 
   /**
    * Get an element from the dom
@@ -87,12 +88,10 @@ const elements = {
       if(albumName) {
         return albumName.textContent;
       }
-    }
-
-    //If listening to a playlist or a mix, get album name from the list
-    if(window.location.href.includes('/playlist/') || window.location.href.includes('/mix/')) {
-      if(currentPlayStatus === 'playing') {
-        const row = window.document.querySelector(this.playing_title).closest('[data-test="tracklist-row"]');
+      //If listening to a playlist or a mix, get album name from the list
+    } else if(window.location.href.includes('/playlist/') || window.location.href.includes('/mix/')) {
+      if(currentPlayStatus === statuses.playing) {
+        const row = window.document.querySelector(this.playing_title).closest(this.tracklist_row);
         if(row) {
          return row.querySelector(this.album_name_cell).textContent;
         }

--- a/src/preload.js
+++ b/src/preload.js
@@ -39,6 +39,9 @@ const elements = {
   duration: '*[data-test="duration-time"]',
   bar: '*[data-test="progress-bar"]',
   footer: "#footerPlayer",
+  album_header_title: '.header-details [data-test="title"]',
+  playing_title: 'span[data-test="table-cell-title"].css-geqnfr',
+  album_name_cell: '[data-test="table-cell-album"]',
 
   /**
    * Get an element from the dom
@@ -75,6 +78,28 @@ const elements = {
     }
 
     return "unknown artist(s)";
+  },
+
+  getAlbumName: function () {
+    //If listening to an album, get its name from the header title
+    if(window.location.href.includes('/album/')) {
+      const albumName = window.document.querySelector(this.album_header_title);
+      if(albumName) {
+        return albumName.textContent;
+      }
+    }
+
+    //If listening to a playlist or a mix, get album name from the list
+    if(window.location.href.includes('/playlist/') || window.location.href.includes('/mix/')) {
+      if(currentPlayStatus === 'playing') {
+        const row = window.document.querySelector(this.playing_title).closest('[data-test="tracklist-row"]');
+        if(row) {
+         return row.querySelector(this.album_name_cell).textContent;
+        }
+      }
+    }
+
+    return "";
   },
 
   /**
@@ -258,6 +283,7 @@ function updateMediaInfo(options, notify) {
         ...{
           "xesam:title": options.title,
           "xesam:artist": [options.message],
+          "xesam:album": options.album,
           "mpris:artUrl": options.image,
           "mpris:length": convertDuration(options.duration) * 1000 * 1000,
         },
@@ -290,6 +316,7 @@ function updateURL() {
 setInterval(function () {
   const title = elements.getText("title");
   const artists = elements.getArtists();
+  const album = elements.getAlbumName();
   const current = elements.getText("current");
   const duration = elements.getText("duration");
   const appName = "Tidal Hifi";
@@ -299,6 +326,7 @@ setInterval(function () {
   const options = {
     title,
     message: artists,
+    album: album,
     status: currentStatus,
     url: currentURL,
     current: current,

--- a/src/scripts/discord.js
+++ b/src/scripts/discord.js
@@ -32,6 +32,7 @@ const observer = (event, arg) => {
           startTimestamp: parseInt(now),
           endTimestamp: parseInt(remaining),
           largeImageKey: mediaInfoModule.mediaInfo.image,
+          largeImageText: (mediaInfoModule.mediaInfo.album) ? mediaInfoModule.mediaInfo.album : 'TIDAL HiFi',
           buttons: [{ label: "Play on Tidal", url: mediaInfoModule.mediaInfo.url }],
         },
       });

--- a/src/scripts/discord.js
+++ b/src/scripts/discord.js
@@ -32,7 +32,7 @@ const observer = (event, arg) => {
           startTimestamp: parseInt(now),
           endTimestamp: parseInt(remaining),
           largeImageKey: mediaInfoModule.mediaInfo.image,
-          largeImageText: (mediaInfoModule.mediaInfo.album) ? mediaInfoModule.mediaInfo.album : 'TIDAL HiFi',
+          largeImageText: (mediaInfoModule.mediaInfo.album) ? mediaInfoModule.mediaInfo.album : `${idleStatus.largeImageText}`,
           buttons: [{ label: "Play on Tidal", url: mediaInfoModule.mediaInfo.url }],
         },
       });

--- a/src/scripts/mediaInfo.js
+++ b/src/scripts/mediaInfo.js
@@ -3,6 +3,7 @@ const statuses = require("./../constants/statuses");
 const mediaInfo = {
   title: "",
   artist: "",
+  album: "",
   icon: "",
   status: statuses.paused,
   url: "",
@@ -20,6 +21,7 @@ const mediaInfoModule = {
 mediaInfoModule.update = function (arg) {
   mediaInfo.title = propOrDefault(arg.title);
   mediaInfo.artist = propOrDefault(arg.message);
+  mediaInfo.album = propOrDefault(arg.album);
   mediaInfo.icon = propOrDefault(arg.icon);
   mediaInfo.url = propOrDefault(arg.url);
   mediaInfo.status = propOrDefault(arg.status);


### PR DESCRIPTION
Tries to get the album name and display it on the player module and on Discord as "LargeImageText".

- KDE media player
![Screenshot_20211221_202143](https://user-images.githubusercontent.com/19615827/146993068-c37145ef-5fc8-4ebd-b73c-a09ef4a7aa44.png)

- Discord
![Screenshot_20211221_202246](https://user-images.githubusercontent.com/19615827/146993180-d0d6db4c-c24a-45e8-b916-27b21f09bd9c.png)

Edit: Guess it fixes [this](https://github.com/Mastermindzh/tidal-hifi/issues/80) issue

