### PR TITLE
Change tidal-hifi to tidal-hifi-bin for AUR

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ snap install --dangerous <path> #for instance: tidal-hifi_1.0.0_amd64.snap
 Arch Linux users can use the AUR to install tidal-hifi:
 
 ```sh
-trizen tidal-hifi
+trizen tidal-hifi-bin
 ```
 
 ### Using source


### PR DESCRIPTION
As I have recently changed the way the package handles the installation I also had to change the package name/base to include the -bin suffix so as follows I have also updated the readme to reflect this change.