### PR TITLE
Fix the link to donations for kwf

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Sometimes it's just easier to start over, cover my own needs and then making it 
 
 ## Buy me a coffee? Please don't
 
-Instead spend some money on a charity I care for: [kwf.nl](https://secure.kwf.nl/donation).
+Instead spend some money on a charity I care for: [kwf.nl](https://www.kwf.nl/donatie/donation?icmp=il-86).
 Inspired by [haydenjames' issue](https://github.com/Mastermindzh/tidal-hifi/issues/27#issuecomment-704198429)
 
 ## Images


### PR DESCRIPTION
The link to KWF's donation page seems to be broken. I've changed it to what I think is the correct page.