### PR TITLE
Update configuration of the desktop file

### DIFF
--- a/build/electron-builder.base.yml
+++ b/build/electron-builder.base.yml
@@ -8,14 +8,14 @@ snap:
     - default
     - screen-inhibit-control
 linux:
-  category: Audio
+  category: AudioVideo
   target:
     - dir
   executableName: tidal-hifi
   desktop:
     Encoding: UTF-8
-    Name: tidal-hifi
-    GenericName: tidal-hifi
+    Name: TIDAL Hi-Fi
+    GenericName: TIDAL Hi-Fi
     Comment: The web version of listen.tidal.com running in electron with hifi support thanks to widevine.
     Icon: icon.png
     StartupNotify: true


### PR DESCRIPTION
Category change is based on the QA Notice from Gentoo package manager: 
```
 * QA Notice: This package installs one or more .desktop files that do not
 * pass validation.
 * 
 * 	/usr/share/applications/tidal-hifi.desktop: error: (will be fatal in the future): value item "Audio" in key "Categories" in group "Desktop Entry" requires another category to be present among the following categories: AudioVideo
 * 
```

The desktop name change may be subjective, but application desktop names usually start with capitalized letters and divide words with spaces. Now it looks kind of weird between other applications. I thought either **TIDAL**, **TIDAL Hi-Fi**, **Tidal** or **Tidal Hi-Fi** could look nice.

![obrazek](https://user-images.githubusercontent.com/17854950/189423821-ba258265-2cae-4c10-b28a-87d38fd33b46.png)
