### PR TITLE
Add ListenBrainz implementation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,14 @@
 {
   "cSpell.words": [
+    "Brainz",
     "flac",
     "geqnfr",
     "hifi",
+    "listenbrainz",
     "playpause",
     "rescrobbler",
+    "scrobble",
+    "scrobbling",
     "Songwhip",
     "trackid",
     "tracklist",

--- a/src/constants/settings.ts
+++ b/src/constants/settings.ts
@@ -20,6 +20,12 @@ export const settings = {
   disableHardwareMediaKeys: "disableHardwareMediaKeys",
   enableCustomHotkeys: "enableCustomHotkeys",
   enableDiscord: "enableDiscord",
+  ListenBrainz: {
+    root: "ListenBrainz",
+    enabled: "ListenBrainz.enabled",
+    api: "ListenBrainz.api",
+    token: "ListenBrainz.token",
+  },
   flags: {
     root: "flags",
     disableHardwareMediaKeys: "flags.disableHardwareMediaKeys",

--- a/src/constants/statuses.ts
+++ b/src/constants/statuses.ts
@@ -1,4 +1,0 @@
-export const statuses = {
-  playing: "playing",
-  paused: "paused",
-};

--- a/src/features/listenbrainz/listenbrainz.ts
+++ b/src/features/listenbrainz/listenbrainz.ts
@@ -4,7 +4,7 @@ import { settings } from "../../constants/settings";
 import { MediaStatus } from "../../models/mediaStatus";
 import Store from "electron-store";
 
-const ListenBrainzStore = new Store();
+const ListenBrainzStore = new Store({name: "listenbrainz"});
 
 export class ListenBrainz {
   /**

--- a/src/features/listenbrainz/listenbrainz.ts
+++ b/src/features/listenbrainz/listenbrainz.ts
@@ -1,0 +1,83 @@
+import axios from "axios";
+import { settingsStore } from "../../scripts/settings";
+import { settings } from "../../constants/settings";
+import { MediaStatus } from "../../models/mediaStatus";
+import Store from "electron-store";
+
+const ListenBrainzStore = new Store();
+
+export class ListenBrainz {
+  /**
+   * Call the ListenBrainz API and create playing now payload
+   * @param title
+   * @param artists
+   * @param status
+   * @param duration
+   */
+  public static async scrobble(title: string, artists: string, status: string, duration: number): Promise<any> {
+    try {
+      if (status == MediaStatus.paused) {
+        return false;
+      } else {
+        // Fetches the OldData required for scrobbling and proceeds to construct a playing_now data payload for the Playing Now area
+        const OldData = ListenBrainzStore.get("OldData") as string[];
+        const playing_data = {
+            listen_type: "playing_now",
+            payload: [
+                {
+                    track_metadata: {
+                        additional_info: {
+                            media_player: "Tidal Hi-Fi",
+                            submission_client: "Tidal Hi-Fi",
+                            music_service: "listen.tidal.com",
+                            duration: duration,
+                        },
+                        artist_name: artists,
+                        track_name: title,
+                    }
+                }
+            ]
+        };
+
+        await axios.post(`${settingsStore.get(settings.ListenBrainz.api)}/1/submit-listens`, playing_data, {
+            headers:{
+                "Content-Type": "application/json",
+                "Authorization": `Token ${settingsStore.get(settings.ListenBrainz.token)}`
+            }
+        });
+        if (!OldData) {
+            ListenBrainzStore.set("OldData", [Math.floor(new Date().getTime() / 1000), title, artists, duration]);
+        } else if (OldData[1] != title) {
+            // This constructs the data required to scrobble the data after the song finishes
+            const scrobble_data = {
+                listen_type: "single",
+                payload: [
+                    {
+                        listened_at: OldData[0],
+                        track_metadata: {
+                            additional_info: {
+                                media_player: "Tidal Hi-Fi",
+                                submission_client: "Tidal Hi-Fi",
+                                music_service: "listen.tidal.com",
+                                duration: OldData[3],
+                            },
+                            artist_name: OldData[2],
+                            track_name: OldData[1],
+                        }
+                    }
+                ]
+            };
+            await axios.post(`${settingsStore.get(settings.ListenBrainz.api)}/1/submit-listens`, scrobble_data, {
+                headers:{
+                    "Content-Type": "application/json",
+                    "Authorization": `Token ${settingsStore.get(settings.ListenBrainz.token)}`
+                }
+            });
+            ListenBrainzStore.set("OldData", [Math.floor(new Date().getTime() / 1000), title, artists, duration]);
+        }
+      }
+    } catch (error) {
+      console.log(JSON.stringify(error));
+    }
+  }
+}

--- a/src/features/listenbrainz/listenbrainz.ts
+++ b/src/features/listenbrainz/listenbrainz.ts
@@ -29,7 +29,7 @@ export class ListenBrainz {
                         additional_info: {
                             media_player: "Tidal Hi-Fi",
                             submission_client: "Tidal Hi-Fi",
-                            music_service: "listen.tidal.com",
+                            music_service: "tidal.com",
                             duration: duration,
                         },
                         artist_name: artists,

--- a/src/features/listenbrainz/listenbrainz.ts
+++ b/src/features/listenbrainz/listenbrainz.ts
@@ -1,12 +1,35 @@
 import axios from "axios";
-import { settingsStore } from "../../scripts/settings";
+import { ipcRenderer } from "electron";
+import Store from "electron-store";
 import { settings } from "../../constants/settings";
 import { MediaStatus } from "../../models/mediaStatus";
-import Store from "electron-store";
+import { settingsStore } from "../../scripts/settings";
+import { Logger } from "../logger";
+import { StoreData } from "./models/storeData";
 
-const ListenBrainzStore = new Store({name: "listenbrainz"});
+const ListenBrainzStore = new Store({ name: "listenbrainz" });
+
+export const ListenBrainzConstants = {
+  oldData: "oldData",
+};
 
 export class ListenBrainz {
+  /**
+   * Create the object to store old information in the Store :)
+   * @param title
+   * @param artists
+   * @param duration
+   * @returns data passed along in an object + a "listenedAt" key with the current time
+   */
+  private static constructStoreData(title: string, artists: string, duration: number): StoreData {
+    return {
+      listenedAt: Math.floor(new Date().getTime() / 1000),
+      title,
+      artists,
+      duration,
+    };
+  }
+
   /**
    * Call the ListenBrainz API and create playing now payload and scrobble old song
    * @param title
@@ -14,70 +37,96 @@ export class ListenBrainz {
    * @param status
    * @param duration
    */
-  public static async scrobble(title: string, artists: string, status: string, duration: number): Promise<any> {
+  public static async scrobble(
+    title: string,
+    artists: string,
+    status: string,
+    duration: number
+  ): Promise<void> {
     try {
-      if (status == MediaStatus.paused) {
-        return false;
+      if (status === MediaStatus.paused) {
+        return;
       } else {
-        // Fetches the OldData required for scrobbling and proceeds to construct a playing_now data payload for the Playing Now area
-        const OldData = ListenBrainzStore.get("OldData") as string[];
+        // Fetches the oldData required for scrobbling and proceeds to construct a playing_now data payload for the Playing Now area
+        const oldData = ListenBrainzStore.get(ListenBrainzConstants.oldData) as StoreData;
         const playing_data = {
-            listen_type: "playing_now",
-            payload: [
-                {
-                    track_metadata: {
-                        additional_info: {
-                            media_player: "Tidal Hi-Fi",
-                            submission_client: "Tidal Hi-Fi",
-                            music_service: "tidal.com",
-                            duration: duration,
-                        },
-                        artist_name: artists,
-                        track_name: title,
-                    }
-                }
-            ]
+          listen_type: "playing_now",
+          payload: [
+            {
+              track_metadata: {
+                additional_info: {
+                  media_player: "Tidal Hi-Fi",
+                  submission_client: "Tidal Hi-Fi",
+                  music_service: "tidal.com",
+                  duration: duration,
+                },
+                artist_name: artists,
+                track_name: title,
+              },
+            },
+          ],
         };
 
-        await axios.post(`${settingsStore.get(settings.ListenBrainz.api)}/1/submit-listens`, playing_data, {
-            headers:{
-                "Content-Type": "application/json",
-                "Authorization": `Token ${settingsStore.get(settings.ListenBrainz.token)}`
-            }
-        });
-        if (!OldData) {
-            ListenBrainzStore.set("OldData", [Math.floor(new Date().getTime() / 1000), title, artists, duration]);
-        } else if (OldData[1] != title) {
+        await axios.post(
+          `${settingsStore.get<string, string>(settings.ListenBrainz.api)}/1/submit-listens`,
+          playing_data,
+          {
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Token ${settingsStore.get<string, string>(
+                settings.ListenBrainz.token
+              )}`,
+            },
+          }
+        );
+        if (!oldData) {
+          ListenBrainzStore.set(
+            ListenBrainzConstants.oldData,
+            this.constructStoreData(title, artists, duration)
+          );
+        } else {
+          if (oldData.title !== title) {
             // This constructs the data required to scrobble the data after the song finishes
             const scrobble_data = {
-                listen_type: "single",
-                payload: [
-                    {
-                        listened_at: OldData[0],
-                        track_metadata: {
-                            additional_info: {
-                                media_player: "Tidal Hi-Fi",
-                                submission_client: "Tidal Hi-Fi",
-                                music_service: "listen.tidal.com",
-                                duration: OldData[3],
-                            },
-                            artist_name: OldData[2],
-                            track_name: OldData[1],
-                        }
-                    }
-                ]
+              listen_type: "single",
+              payload: [
+                {
+                  listened_at: oldData.listenedAt,
+                  track_metadata: {
+                    additional_info: {
+                      media_player: "Tidal Hi-Fi",
+                      submission_client: "Tidal Hi-Fi",
+                      music_service: "listen.tidal.com",
+                      duration: oldData.duration,
+                    },
+                    artist_name: oldData.artists,
+                    track_name: oldData.title,
+                  },
+                },
+              ],
             };
-            await axios.post(`${settingsStore.get(settings.ListenBrainz.api)}/1/submit-listens`, scrobble_data, {
-                headers:{
-                    "Content-Type": "application/json",
-                    "Authorization": `Token ${settingsStore.get(settings.ListenBrainz.token)}`
-                }
-            });
-            ListenBrainzStore.set("OldData", [Math.floor(new Date().getTime() / 1000), title, artists, duration]);
+            await axios.post(
+              `${settingsStore.get<string, string>(settings.ListenBrainz.api)}/1/submit-listens`,
+              scrobble_data,
+              {
+                headers: {
+                  "Content-Type": "application/json",
+                  Authorization: `Token ${settingsStore.get<string, string>(
+                    settings.ListenBrainz.token
+                  )}`,
+                },
+              }
+            );
+            ListenBrainzStore.set(
+              ListenBrainzConstants.oldData,
+              this.constructStoreData(title, artists, duration)
+            );
+          }
         }
       }
     } catch (error) {
-      console.log(JSON.stringify(error));
+      const logger = new Logger(ipcRenderer);
+      logger.log(JSON.stringify(error));
     }
   }
 }

--- a/src/features/listenbrainz/listenbrainz.ts
+++ b/src/features/listenbrainz/listenbrainz.ts
@@ -8,7 +8,7 @@ const ListenBrainzStore = new Store({name: "listenbrainz"});
 
 export class ListenBrainz {
   /**
-   * Call the ListenBrainz API and create playing now payload
+   * Call the ListenBrainz API and create playing now payload and scrobble old song
    * @param title
    * @param artists
    * @param status

--- a/src/features/listenbrainz/listenbrainz.ts
+++ b/src/features/listenbrainz/listenbrainz.ts
@@ -81,3 +81,5 @@ export class ListenBrainz {
     }
   }
 }
+
+export { ListenBrainzStore };

--- a/src/features/listenbrainz/models/storeData.ts
+++ b/src/features/listenbrainz/models/storeData.ts
@@ -1,0 +1,9 @@
+/**
+ * Data saved for ListenBrainz
+ */
+export interface StoreData {
+  listenedAt: number;
+  title: string;
+  artists: string;
+  duration: number;
+}

--- a/src/features/logger.ts
+++ b/src/features/logger.ts
@@ -26,8 +26,7 @@ export class Logger {
   public log(content: string, object: object = {}) {
     if (this.ipcRenderer) {
       this.ipcRenderer.send(globalEvents.log, { content, object });
-    } else {
-      console.log(`${content} \n ${JSON.stringify(object, null, 2)}`);
     }
+    console.log(`${content} \n ${JSON.stringify(object, null, 2)}`);
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -58,7 +58,7 @@ function setFlags() {
 }
 
 /**
- * Update the menuBarVisbility according to the store value
+ * Update the menuBarVisibility according to the store value
  *
  */
 function syncMenuBarWithStore() {

--- a/src/pages/settings/preload.ts
+++ b/src/pages/settings/preload.ts
@@ -146,7 +146,7 @@ window.addEventListener("DOMContentLoaded", () => {
       }
       // Live update the view for ListenBrainz input, hide if disabled/show if enabled
       if (source.value === "on" && source.id === "enableListenBrainz") {
-        source.checked ? document.getElementById("listenbrainz__options").setAttribute("hidden", "false") : document.getElementById("listenbrainz__options").setAttribute("hidden", "true");
+        source.checked ? document.getElementById("listenbrainz__options").removeAttribute("hidden") : document.getElementById("listenbrainz__options").setAttribute("hidden", "true");
       }
       ipcRenderer.send(globalEvents.storeChanged);
     });
@@ -199,7 +199,7 @@ window.addEventListener("DOMContentLoaded", () => {
   ListenBrainzToken = get("ListenBrainzToken");
 
   refreshSettings();
-  enableListenBrainz.checked ? document.getElementById("listenbrainz__options").hidden = false : document.getElementById("listenbrainz__options").hidden = true;
+  enableListenBrainz.checked ? document.getElementById("listenbrainz__options").removeAttribute("hidden") : document.getElementById("listenbrainz__options").setAttribute("hidden", "true");
 
   addInputListener(adBlock, settings.adBlock);
   addInputListener(api, settings.api);

--- a/src/pages/settings/preload.ts
+++ b/src/pages/settings/preload.ts
@@ -146,7 +146,7 @@ window.addEventListener("DOMContentLoaded", () => {
       }
       // Live update the view for ListenBrainz input, hide if disabled/show if enabled
       if (source.value === "on" && source.id === "enableListenBrainz") {
-        source.checked ? document.getElementById("listenbrainz__options").hidden = false : document.getElementById("listenbrainz__options").hidden = true;
+        source.checked ? document.getElementById("listenbrainz__options").setAttribute("hidden", "false") : document.getElementById("listenbrainz__options").setAttribute("hidden", "true");
       }
       ipcRenderer.send(globalEvents.storeChanged);
     });

--- a/src/pages/settings/preload.ts
+++ b/src/pages/settings/preload.ts
@@ -25,7 +25,11 @@ let adBlock: HTMLInputElement,
   skippedArtists: HTMLInputElement,
   theme: HTMLSelectElement,
   trayIcon: HTMLInputElement,
-  updateFrequency: HTMLInputElement;
+  updateFrequency: HTMLInputElement,
+  enableListenBrainz: HTMLInputElement,
+  ListenBrainzAPI: HTMLInputElement,
+  ListenBrainzToken: HTMLInputElement;
+
 function getThemeFiles() {
   const selectElement = document.getElementById("themesList") as HTMLSelectElement;
   const builtInThemes = getThemeListFromDirectory(process.resourcesPath);
@@ -87,6 +91,9 @@ function refreshSettings() {
   skippedArtists.value = settingsStore.get<string, string[]>(settings.skippedArtists).join("\n");
   trayIcon.checked = settingsStore.get(settings.trayIcon);
   updateFrequency.value = settingsStore.get(settings.updateFrequency);
+  enableListenBrainz.checked = settingsStore.get(settings.ListenBrainz.enabled);
+  ListenBrainzAPI.value = settingsStore.get(settings.ListenBrainz.api);
+  ListenBrainzToken.value = settingsStore.get(settings.ListenBrainz.token);
 }
 
 /**
@@ -183,6 +190,9 @@ window.addEventListener("DOMContentLoaded", () => {
   skippedArtists = get("skippedArtists");
   singleInstance = get("singleInstance");
   updateFrequency = get("updateFrequency");
+  enableListenBrainz = get("enableListenBrainz");
+  ListenBrainzAPI = get("ListenBrainzAPI");
+  ListenBrainzToken = get("ListenBrainzToken");
 
   refreshSettings();
 
@@ -206,4 +216,7 @@ window.addEventListener("DOMContentLoaded", () => {
   addSelectListener(theme, settings.theme);
   addInputListener(trayIcon, settings.trayIcon);
   addInputListener(updateFrequency, settings.updateFrequency);
+  addInputListener(enableListenBrainz, settings.ListenBrainz.enabled);
+  addTextAreaListener(ListenBrainzAPI, settings.ListenBrainz.api);
+  addTextAreaListener(ListenBrainzToken, settings.ListenBrainz.token);
 });

--- a/src/pages/settings/preload.ts
+++ b/src/pages/settings/preload.ts
@@ -144,6 +144,10 @@ window.addEventListener("DOMContentLoaded", () => {
       } else {
         settingsStore.set(key, source.value);
       }
+      // Live update the view for ListenBrainz input, hide if disabled/show if enabled
+      if (source.value === "on" && source.id === "enableListenBrainz") {
+        source.checked ? document.getElementById("listenbrainz__options").hidden = false : document.getElementById("listenbrainz__options").hidden = true;
+      }
       ipcRenderer.send(globalEvents.storeChanged);
     });
   }
@@ -195,6 +199,7 @@ window.addEventListener("DOMContentLoaded", () => {
   ListenBrainzToken = get("ListenBrainzToken");
 
   refreshSettings();
+  enableListenBrainz.checked ? document.getElementById("listenbrainz__options").hidden = false : document.getElementById("listenbrainz__options").hidden = true;
 
   addInputListener(adBlock, settings.adBlock);
   addInputListener(api, settings.api);

--- a/src/pages/settings/settings.html
+++ b/src/pages/settings/settings.html
@@ -221,20 +221,22 @@
                 <span class="switch__slider"></span>
               </label>
             </div>
-            <div class="group__option">
-              <div class="group__description">
-                <h4>ListenBrainz API Url</h4>
-                <p>There are multiple instances for ListenBrainz you can set the corresponding API url below.</p>
+            <div id="listenbrainz__options" hidden="true">
+              <div class="group__option">
+                <div class="group__description">
+                  <h4>ListenBrainz API Url</h4>
+                  <p>There are multiple instances for ListenBrainz you can set the corresponding API url below.</p>
+                </div>
               </div>
-            </div>
-            <textarea id="ListenBrainzAPI" class="textarea" cols="1" rows="1" spellcheck="false"></textarea>
-            <div class="group__option">
-              <div class="group__description">
-                <h4>ListenBrainz User Token</h4>
-                <p>Provide the user token you can get from the settings page.</p>
+              <textarea id="ListenBrainzAPI" class="textarea" cols="1" rows="1" spellcheck="false"></textarea>
+              <div class="group__option">
+                <div class="group__description">
+                  <h4>ListenBrainz User Token</h4>
+                  <p>Provide the user token you can get from the settings page.</p>
+                </div>
               </div>
+              <textarea id="ListenBrainzToken" class="textarea" cols="1" rows="1" spellcheck="false"></textarea>
             </div>
-            <textarea id="ListenBrainzToken" class="textarea" cols="1" rows="1" spellcheck="false"></textarea>
           </div>
         </section>
 

--- a/src/pages/settings/settings.html
+++ b/src/pages/settings/settings.html
@@ -211,9 +211,12 @@
                 <span class="switch__slider"></span>
               </label>
             </div>
+          </div>
+          <div class="group">
+            <p class="group__title">ListenBrainz</p>
             <div class="group__option">
               <div class="group__description">
-                <h4>ListenBrainz</h4>
+                <h4>Enable ListenBrainz</h4>
                 <p>Scrobble your listens directly to ListenBrainz.</p>
               </div>
               <label class="switch">

--- a/src/pages/settings/settings.html
+++ b/src/pages/settings/settings.html
@@ -211,6 +211,30 @@
                 <span class="switch__slider"></span>
               </label>
             </div>
+            <div class="group__option">
+              <div class="group__description">
+                <h4>ListenBrainz</h4>
+                <p>Scrobble your listens directly to ListenBrainz.</p>
+              </div>
+              <label class="switch">
+                <input id="enableListenBrainz" type="checkbox" />
+                <span class="switch__slider"></span>
+              </label>
+            </div>
+            <div class="group__option">
+              <div class="group__description">
+                <h4>ListenBrainz API Url</h4>
+                <p>There are multiple instances for ListenBrainz you can set the corresponding API url below.</p>
+              </div>
+            </div>
+            <textarea id="ListenBrainzAPI" class="textarea" cols="1" rows="1" spellcheck="false"></textarea>
+            <div class="group__option">
+              <div class="group__description">
+                <h4>ListenBrainz User Token</h4>
+                <p>Provide the user token you can get from the settings page.</p>
+              </div>
+            </div>
+            <textarea id="ListenBrainzToken" class="textarea" cols="1" rows="1" spellcheck="false"></textarea>
           </div>
         </section>
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -377,8 +377,13 @@ function updateMediaInfo(options: Options, notify: boolean) {
       };
       player.playbackStatus = options.status == statuses.paused ? "Paused" : "Playing";
     }
-    if (settingsStore.get(settings.ListenBrainz.enabled) && (ListenBrainzStore.get("OldData") as string[][1]) !== options.title) {
-      ListenBrainz.scrobble(options.title, options.artists, options.status, convertDuration(options.duration));
+    if (settingsStore.get(settings.ListenBrainz.enabled)) {
+      const data = ListenBrainzStore.get("OldData") as string[];
+      if (data && data[1] !== options.title) {
+        ListenBrainz.scrobble(options.title, options.artists, options.status, convertDuration(options.duration));
+      } else if (!data) {
+        ListenBrainz.scrobble(options.title, options.artists, options.status, convertDuration(options.duration));
+      }
     }
   }
 }

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -6,7 +6,7 @@ import { globalEvents } from "./constants/globalEvents";
 import { settings } from "./constants/settings";
 import { statuses } from "./constants/statuses";
 import { Songwhip } from "./features/songwhip/songwhip";
-import { ListenBrainz } from "./features/listenbrainz/listenbrainz";
+import { ListenBrainz, ListenBrainzStore } from "./features/listenbrainz/listenbrainz";
 import { Options } from "./models/options";
 import { downloadFile } from "./scripts/download";
 import { addHotkey } from "./scripts/hotkeys";
@@ -203,6 +203,11 @@ function playPause() {
 }
 
 /**
+ * Clears the old listenbrainz data on launch
+ */
+ListenBrainzStore.clear();
+
+/**
  * Add hotkeys for when tidal is focused
  * Reflects the desktop hotkeys found on:
  * https://defkey.com/tidal-desktop-shortcuts
@@ -372,6 +377,9 @@ function updateMediaInfo(options: Options, notify: boolean) {
       };
       player.playbackStatus = options.status == statuses.paused ? "Paused" : "Playing";
     }
+    if (settingsStore.get(settings.ListenBrainz.enabled) && (ListenBrainzStore.get("OldData") as string[][1]) !== options.title) {
+      ListenBrainz.scrobble(options.title, options.artists, options.status, convertDuration(options.duration));
+    }
   }
 }
 
@@ -469,9 +477,6 @@ setInterval(function () {
     updateMediaInfo(options, titleOrArtistsChanged);
     if (titleOrArtistsChanged) {
       updateMediaSession(options);
-      if (settingsStore.get(settings.ListenBrainz.enabled)) {
-        ListenBrainz.scrobble(options.title, options.artists, options.status, convertDuration(options.duration));
-      }
     }
   });
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -6,6 +6,7 @@ import { globalEvents } from "./constants/globalEvents";
 import { settings } from "./constants/settings";
 import { statuses } from "./constants/statuses";
 import { Songwhip } from "./features/songwhip/songwhip";
+import { ListenBrainz } from "./features/listenbrainz/listenbrainz";
 import { Options } from "./models/options";
 import { downloadFile } from "./scripts/download";
 import { addHotkey } from "./scripts/hotkeys";
@@ -468,6 +469,9 @@ setInterval(function () {
     updateMediaInfo(options, titleOrArtistsChanged);
     if (titleOrArtistsChanged) {
       updateMediaSession(options);
+      if (settingsStore.get(settings.ListenBrainz.enabled)) {
+        ListenBrainz.scrobble(options.title, options.artists, options.status, convertDuration(options.duration));
+      }
     }
   });
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -4,20 +4,25 @@ import fs from "fs";
 import Player from "mpris-service";
 import { globalEvents } from "./constants/globalEvents";
 import { settings } from "./constants/settings";
-import { statuses } from "./constants/statuses";
 import { Songwhip } from "./features/songwhip/songwhip";
-import { ListenBrainz, ListenBrainzStore } from "./features/listenbrainz/listenbrainz";
+import {
+  ListenBrainz,
+  ListenBrainzConstants,
+  ListenBrainzStore,
+} from "./features/listenbrainz/listenbrainz";
 import { Options } from "./models/options";
 import { downloadFile } from "./scripts/download";
 import { addHotkey } from "./scripts/hotkeys";
 import { settingsStore } from "./scripts/settings";
 import { setTitle } from "./scripts/window-functions";
+import { StoreData } from "./features/listenbrainz/models/storeData";
+import { MediaStatus } from "./models/mediaStatus";
 
 const notificationPath = `${app.getPath("userData")}/notification.jpg`;
 const appName = "Tidal Hifi";
 let currentSong = "";
 let player: Player;
-let currentPlayStatus = statuses.paused;
+let currentPlayStatus = MediaStatus.paused;
 
 const elements = {
   play: '*[data-test="play"]',
@@ -106,7 +111,7 @@ const elements = {
       window.location.href.includes("/playlist/") ||
       window.location.href.includes("/mix/")
     ) {
-      if (currentPlayStatus === statuses.playing) {
+      if (currentPlayStatus === MediaStatus.playing) {
         // find the currently playing element from the list (which might be in an album icon), traverse back up to the mediaItem (row) and select the album cell.
         // document.querySelector("[class^='isPlayingIcon'], [data-test-is-playing='true']").closest('[data-type="mediaItem"]').querySelector('[class^="album"]').textContent
         const row = window.document.querySelector(this.currentlyPlaying).closest(this.mediaItem);
@@ -179,7 +184,7 @@ function addCustomCss() {
  * make sure it returns a number, if not use the default
  */
 function getUpdateFrequency() {
-  const storeValue = settingsStore.get(settings.updateFrequency) as number;
+  const storeValue = settingsStore.get<string, number>(settings.updateFrequency);
   const defaultValue = 500;
 
   if (!isNaN(storeValue)) {
@@ -280,7 +285,7 @@ function handleLogout() {
       defaultId: 2,
     })
     .then((result: { response: number }) => {
-      if (logoutOptions.indexOf("Yes, please") == result.response) {
+      if (logoutOptions.indexOf("Yes, please") === result.response) {
         for (let i = 0; i < window.localStorage.length; i++) {
           const key = window.localStorage.key(i);
           if (key.startsWith("_TIDAL_activeSession")) {
@@ -322,6 +327,8 @@ function addIPCEventListeners() {
         case globalEvents.pause:
           elements.click("pause");
           break;
+        default:
+          break;
       }
     });
   });
@@ -336,9 +343,9 @@ function getCurrentlyPlayingStatus() {
 
   // if pause button is visible tidal is playing
   if (pause) {
-    status = statuses.playing;
+    status = MediaStatus.playing;
   } else {
-    status = statuses.paused;
+    status = MediaStatus.paused;
   }
   return status;
 }
@@ -363,27 +370,41 @@ function updateMediaInfo(options: Options, notify: boolean) {
     if (settingsStore.get(settings.notifications) && notify) {
       new Notification({ title: options.title, body: options.artists, icon: options.icon }).show();
     }
-    if (player) {
-      player.metadata = {
-        ...player.metadata,
-        ...{
-          "xesam:title": options.title,
-          "xesam:artist": [options.artists],
-          "xesam:album": options.album,
-          "mpris:artUrl": options.image,
-          "mpris:length": convertDuration(options.duration) * 1000 * 1000,
-          "mpris:trackid": "/org/mpris/MediaPlayer2/track/" + getTrackID(),
-        },
-      };
-      player.playbackStatus = options.status == statuses.paused ? "Paused" : "Playing";
-    }
-    if (settingsStore.get(settings.ListenBrainz.enabled)) {
-      const data = ListenBrainzStore.get("OldData") as string[];
-      if (data && data[1] !== options.title) {
-        ListenBrainz.scrobble(options.title, options.artists, options.status, convertDuration(options.duration));
-      } else if (!data) {
-        ListenBrainz.scrobble(options.title, options.artists, options.status, convertDuration(options.duration));
-      }
+    updateMpris(options);
+    updateListenBrainz(options);
+  }
+}
+
+function updateMpris(options: Options) {
+  if (player) {
+    player.metadata = {
+      ...player.metadata,
+      ...{
+        "xesam:title": options.title,
+        "xesam:artist": [options.artists],
+        "xesam:album": options.album,
+        "mpris:artUrl": options.image,
+        "mpris:length": convertDuration(options.duration) * 1000 * 1000,
+        "mpris:trackid": "/org/mpris/MediaPlayer2/track/" + getTrackID(),
+      },
+    };
+    player.playbackStatus = options.status === MediaStatus.paused ? "Paused" : "Playing";
+  }
+}
+
+function updateListenBrainz(options: Options) {
+  if (settingsStore.get(settings.ListenBrainz.enabled)) {
+    const oldData = ListenBrainzStore.get(ListenBrainzConstants.oldData) as StoreData;
+    if (
+      (!oldData && options.status === MediaStatus.playing) ||
+      (oldData && oldData.title !== options.title)
+    ) {
+      ListenBrainz.scrobble(
+        options.title,
+        options.artists,
+        options.status,
+        convertDuration(options.duration)
+      );
     }
   }
 }

--- a/src/scripts/express.ts
+++ b/src/scripts/express.ts
@@ -1,11 +1,11 @@
 import { BrowserWindow, dialog } from "electron";
 import express, { Response } from "express";
 import fs from "fs";
+import { settings } from "../constants/settings";
+import { MediaStatus } from "../models/mediaStatus";
 import { globalEvents } from "./../constants/globalEvents";
-import { statuses } from "./../constants/statuses";
 import { mediaInfo } from "./mediaInfo";
 import { settingsStore } from "./settings";
-import { settings } from "../constants/settings";
 
 /**
  * Function to enable tidal-hifi's express api
@@ -44,7 +44,7 @@ export const startExpress = (mainWindow: BrowserWindow) => {
     expressApp.get("/next", (req, res) => handleGlobalEvent(res, globalEvents.next));
     expressApp.get("/previous", (req, res) => handleGlobalEvent(res, globalEvents.previous));
     expressApp.get("/playpause", (req, res) => {
-      if (mediaInfo.status == statuses.playing) {
+      if (mediaInfo.status === MediaStatus.playing) {
         handleGlobalEvent(res, globalEvents.pause);
       } else {
         handleGlobalEvent(res, globalEvents.play);

--- a/src/scripts/mediaInfo.ts
+++ b/src/scripts/mediaInfo.ts
@@ -1,12 +1,12 @@
 import { MediaInfo } from "../models/mediaInfo";
-import { statuses } from "./../constants/statuses";
+import { MediaStatus } from "../models/mediaStatus";
 
 export const mediaInfo = {
   title: "",
   artists: "",
   album: "",
   icon: "",
-  status: statuses.paused,
+  status: MediaStatus.paused as string,
   url: "",
   current: "",
   duration: "",

--- a/src/scripts/settings.ts
+++ b/src/scripts/settings.ts
@@ -18,6 +18,11 @@ export const settingsStore = new Store({
     disableHardwareMediaKeys: false,
     enableCustomHotkeys: false,
     enableDiscord: false,
+    ListenBrainz: {
+      enabled: false,
+      api: "https://api.listenbrainz.org",
+      token: "",
+    },
     flags: {
       gpuRasterization: true,
       disableHardwareMediaKeys: false,


### PR DESCRIPTION
This should close #253 

I also noticed that the two lines

```js
skippedArtists.value = settingsStore.get<string, string[]>(settings.skippedArtists).join("\n");
customCSS.value = settingsStore.get<string, string[]>(settings.customCSS).join("\n");
```

in refreshSettings seem to break the settings window as it can't run the refresh function due to those two lines throwing a `.join() is not a function` error I didn't fix this error but I thought I would let you know as I was also confused as to why my normal install of tidal-hifi does not show my actual settings and defaults to everything being off and empty.