### PR TITLE
Bump tidal version string in settings.html

### DIFF
--- a/src/pages/settings/settings.html
+++ b/src/pages/settings/settings.html
@@ -389,7 +389,7 @@
           <img alt="tidal icon" class="about-section__icon" src="./icon.png" />
           <h4>TIDAL Hi-Fi</h4>
           <div class="about-section__version">
-            <a href="">5.7.0</a>
+            <a href="">5.7.1</a>
           </div>
           <div class="about-section__links">
             <a href="https://github.com/mastermindzh/tidal-hifi/" class="about-section__button">Github <i


### PR DESCRIPTION
The settings page is incorrectly showing 5.7.0 on version 5.7.1:

```
$ ls -l $(which tidal-hifi)
lrwxrwxrwx 4 root root 75 Jan  1  1970 /run/current-system/sw/bin/tidal-hifi -> /nix/store/rlzjslwz11i5h7l4byfk4557p1ns4025-tidal-hifi-5.7.1/bin/tidal-hifi
```

![image](https://github.com/Mastermindzh/tidal-hifi/assets/18282288/f8b0d537-13af-4506-90e7-acf8f8cfb2a9)
