### PR TITLE
More customizable Discord-Presence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.9.0]
+
+- More Discord options:
+  - Added the ability to hide the current song from the discord activity and display a custom text instead
+  - Added the ability to customize the text that is shown when no song is playing
+  - Discord now reacts to pausing/unpausing events
+- Refactored media info updates so it only updates the required info, fixes #342, #306
+- Added 5.9.0 logs/versions/migrations
+
 ## [5.8.0]
 
 - Updated Electron to 28.1.1 (fixes [325](https://github.com/Mastermindzh/tidal-hifi/issues/325))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidal-hifi",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "description": "Tidal on Electron with widevine(hifi) support",
   "main": "ts-dist/main.js",
   "scripts": {

--- a/src/constants/settings.ts
+++ b/src/constants/settings.ts
@@ -24,6 +24,9 @@ export const settings = {
     detailsPrefix: "discord.detailsPrefix",
     buttonText: "discord.buttonText",
     includeTimestamps: "discord.includeTimestamps",
+    showSong: "discord.showSong",
+    idleText: "discord.idleText",
+    listeningText: "discord.listeningText",
   },
   ListenBrainz: {
     root: "ListenBrainz",

--- a/src/constants/settings.ts
+++ b/src/constants/settings.ts
@@ -26,7 +26,7 @@ export const settings = {
     includeTimestamps: "discord.includeTimestamps",
     showSong: "discord.showSong",
     idleText: "discord.idleText",
-    listeningText: "discord.listeningText",
+    usingText: "discord.usingText",
   },
   ListenBrainz: {
     root: "ListenBrainz",

--- a/src/pages/settings/preload.ts
+++ b/src/pages/settings/preload.ts
@@ -20,6 +20,11 @@ const switchesWithSettings = {
     classToHide: "discord_options",
     settingsKey: settings.enableDiscord,
   },
+  discord_show_song: {
+    switch: "discord_show_song",
+    classToHide: "discord_show_song_options",
+    settingsKey: settings.discord.showSong,
+  }
 };
 
 let adBlock: HTMLInputElement,
@@ -49,7 +54,10 @@ let adBlock: HTMLInputElement,
   enableWaylandSupport: HTMLInputElement,
   discord_details_prefix: HTMLInputElement,
   discord_include_timestamps: HTMLInputElement,
-  discord_button_text: HTMLInputElement;
+  discord_button_text: HTMLInputElement,
+  discord_show_song: HTMLInputElement,
+  discord_idle_text: HTMLInputElement,
+  discord_listening_text: HTMLInputElement;
 
 addCustomCss(app);
 
@@ -138,6 +146,9 @@ function refreshSettings() {
     discord_details_prefix.value = settingsStore.get(settings.discord.detailsPrefix);
     discord_include_timestamps.checked = settingsStore.get(settings.discord.includeTimestamps);
     discord_button_text.value = settingsStore.get(settings.discord.buttonText);
+    discord_show_song.checked = settingsStore.get(settings.discord.showSong);
+    discord_idle_text.value = settingsStore.get(settings.discord.idleText);
+    discord_listening_text.value = settingsStore.get(settings.discord.listeningText);
 
     // set state of all switches with additional settings
     Object.values(switchesWithSettings).forEach((settingSwitch) => {
@@ -251,6 +262,9 @@ window.addEventListener("DOMContentLoaded", () => {
   discord_include_timestamps = get("discord_include_timestamps");
   listenbrainz_delay = get("listenbrainz_delay");
   discord_button_text = get("discord_button_text");
+  discord_show_song = get("discord_show_song");
+  discord_listening_text = get("discord_listening_text");
+  discord_idle_text = get("discord_idle_text")
 
   refreshSettings();
   addInputListener(adBlock, settings.adBlock);
@@ -285,4 +299,7 @@ window.addEventListener("DOMContentLoaded", () => {
   addInputListener(discord_details_prefix, settings.discord.detailsPrefix);
   addInputListener(discord_include_timestamps, settings.discord.includeTimestamps);
   addInputListener(discord_button_text, settings.discord.buttonText);
+  addInputListener(discord_show_song, settings.discord.showSong, switchesWithSettings.discord_show_song);
+  addInputListener(discord_idle_text, settings.discord.idleText);
+  addInputListener(discord_listening_text, settings.discord.listeningText);
 });

--- a/src/pages/settings/preload.ts
+++ b/src/pages/settings/preload.ts
@@ -57,7 +57,7 @@ let adBlock: HTMLInputElement,
   discord_button_text: HTMLInputElement,
   discord_show_song: HTMLInputElement,
   discord_idle_text: HTMLInputElement,
-  discord_listening_text: HTMLInputElement;
+  discord_using_text: HTMLInputElement;
 
 addCustomCss(app);
 
@@ -148,7 +148,7 @@ function refreshSettings() {
     discord_button_text.value = settingsStore.get(settings.discord.buttonText);
     discord_show_song.checked = settingsStore.get(settings.discord.showSong);
     discord_idle_text.value = settingsStore.get(settings.discord.idleText);
-    discord_listening_text.value = settingsStore.get(settings.discord.listeningText);
+    discord_using_text.value = settingsStore.get(settings.discord.usingText);
 
     // set state of all switches with additional settings
     Object.values(switchesWithSettings).forEach((settingSwitch) => {
@@ -263,7 +263,7 @@ window.addEventListener("DOMContentLoaded", () => {
   listenbrainz_delay = get("listenbrainz_delay");
   discord_button_text = get("discord_button_text");
   discord_show_song = get("discord_show_song");
-  discord_listening_text = get("discord_listening_text");
+  discord_using_text = get("discord_using_text");
   discord_idle_text = get("discord_idle_text")
 
   refreshSettings();
@@ -301,5 +301,5 @@ window.addEventListener("DOMContentLoaded", () => {
   addInputListener(discord_button_text, settings.discord.buttonText);
   addInputListener(discord_show_song, settings.discord.showSong, switchesWithSettings.discord_show_song);
   addInputListener(discord_idle_text, settings.discord.idleText);
-  addInputListener(discord_listening_text, settings.discord.listeningText);
+  addInputListener(discord_using_text, settings.discord.usingText);
 });

--- a/src/pages/settings/settings.html
+++ b/src/pages/settings/settings.html
@@ -227,9 +227,9 @@
 
               <div class="group__option" class="hidden">
                 <div class="group__description">
-                  <h4>Listening Text</h4>
-                  <p>The text displayed on Discord's rich presence while listening to a song.</p>
-                  <input id="discord_listening_text" type="text" class="text-input" name="discord_listening_text" />
+                  <h4>Using Tidal Text</h4>
+                  <p>The text displayed on Discord's rich presence while "showSong" is turned off</p>
+                  <input id="discord_using_text" type="text" class="text-input" name="discord_using_text" />
                 </div>
               </div>
 
@@ -432,7 +432,7 @@
           <img alt="tidal icon" class="about-section__icon" src="./icon.png" />
           <h4>TIDAL Hi-Fi</h4>
           <div class="about-section__version">
-            <a href="https://github.com/Mastermindzh/tidal-hifi/releases/tag/5.8.0">5.8.0</a>
+            <a href="https://github.com/Mastermindzh/tidal-hifi/releases/tag/5.9.0">5.9.0</a>
           </div>
           <div class="about-section__links">
             <a href="https://github.com/mastermindzh/tidal-hifi/" class="about-section__button">Github <i

--- a/src/pages/settings/settings.html
+++ b/src/pages/settings/settings.html
@@ -229,19 +229,50 @@
 
               <div class="group__option" class="hidden">
                 <div class="group__description">
-                  <h4>Details prefix</h4>
-                  <p>Prefix for the "details" field of Discord's rich presence.</p>
-                  <input id="discord_details_prefix" type="text" class="text-input" name="discord_details_prefix" />
+                  <h4>Show song</h4>
+                  <p>Show the current song in the Discord client</p>
+                </div>
+                <label class="switch">
+                  <input id="discord_show_song" type="checkbox" />
+                  <span class="switch__slider"></span>
+                </label>
+              </div>
+
+              <div class="group__option" class="hidden">
+                <div class="group__description">
+                  <h4>Idle Text</h4>
+                  <p>The text displayed on Discord's rich presence while idling in the app.</p>
+                  <input id="discord_idle_text" type="text" class="text-input" name="discord_idle_text" />
                 </div>
               </div>
 
-              <div class="group__option">
+              <div class="group__option" class="hidden">
                 <div class="group__description">
-                  <h4>Button text</h4>
-                  <p>Text to display on the button below the song information.</p>
-                  <input id="discord_button_text" type="text" class="text-input" name="discord_button_text" />
+                  <h4>Listening Text</h4>
+                  <p>The text displayed on Discord's rich presence while listening to a song.</p>
+                  <input id="discord_listening_text" type="text" class="text-input" name="discord_listening_text" />
                 </div>
               </div>
+
+              <div id="discord_show_song_options" class="hidden">
+
+                <div class="group__option" class="hidden">
+                  <div class="group__description">
+                    <h4>Details prefix</h4>
+                    <p>Prefix for the "details" field of Discord's rich presence.</p>
+                    <input id="discord_details_prefix" type="text" class="text-input" name="discord_details_prefix" />
+                  </div>
+                </div>
+
+                <div class="group__option">
+                  <div class="group__description">
+                    <h4>Button text</h4>
+                    <p>Text to display on the button below the song information.</p>
+                    <input id="discord_button_text" type="text" class="text-input" name="discord_button_text" />
+                  </div>
+                </div>
+              </div>
+
             </div>
           </div>
           <div class="group">

--- a/src/pages/settings/settings.html
+++ b/src/pages/settings/settings.html
@@ -229,17 +229,6 @@
 
               <div class="group__option" class="hidden">
                 <div class="group__description">
-                  <h4>Show song</h4>
-                  <p>Show the current song in the Discord client</p>
-                </div>
-                <label class="switch">
-                  <input id="discord_show_song" type="checkbox" />
-                  <span class="switch__slider"></span>
-                </label>
-              </div>
-
-              <div class="group__option" class="hidden">
-                <div class="group__description">
                   <h4>Idle Text</h4>
                   <p>The text displayed on Discord's rich presence while idling in the app.</p>
                   <input id="discord_idle_text" type="text" class="text-input" name="discord_idle_text" />
@@ -252,6 +241,17 @@
                   <p>The text displayed on Discord's rich presence while listening to a song.</p>
                   <input id="discord_listening_text" type="text" class="text-input" name="discord_listening_text" />
                 </div>
+              </div>
+
+              <div class="group__option" class="hidden">
+                <div class="group__description">
+                  <h4>Show song</h4>
+                  <p>Show the current song in the Discord client</p>
+                </div>
+                <label class="switch">
+                  <input id="discord_show_song" type="checkbox" />
+                  <span class="switch__slider"></span>
+                </label>
               </div>
 
               <div id="discord_show_song_options" class="hidden">

--- a/src/pages/settings/settings.html
+++ b/src/pages/settings/settings.html
@@ -216,16 +216,6 @@
               </label>
             </div>
             <div id="discord_options">
-              <div class="group__option" class="hidden">
-                <div class="group__description">
-                  <h4>Include timestamps</h4>
-                  <p>Show current/end playtime in the Discord client</p>
-                </div>
-                <label class="switch">
-                  <input id="discord_include_timestamps" type="checkbox" />
-                  <span class="switch__slider"></span>
-                </label>
-              </div>
 
               <div class="group__option" class="hidden">
                 <div class="group__description">
@@ -255,6 +245,17 @@
               </div>
 
               <div id="discord_show_song_options" class="hidden">
+
+                <div class="group__option" class="hidden">
+                  <div class="group__description">
+                    <h4>Include timestamps</h4>
+                    <p>Show current/end playtime in the Discord client</p>
+                  </div>
+                  <label class="switch">
+                    <input id="discord_include_timestamps" type="checkbox" />
+                    <span class="switch__slider"></span>
+                  </label>
+                </div>
 
                 <div class="group__option" class="hidden">
                   <div class="group__description">

--- a/src/scripts/discord.ts
+++ b/src/scripts/discord.ts
@@ -1,4 +1,4 @@
-import { Client } from "discord-rpc";
+import { Client, Presence } from "discord-rpc";
 import { app, ipcMain } from "electron";
 import { globalEvents } from "../constants/globalEvents";
 import { settings } from "../constants/settings";
@@ -18,58 +18,54 @@ function timeToSeconds(timeArray: string[]) {
 export let rpc: Client;
 
 const observer = () => {
-  if (mediaInfo.status === MediaStatus.paused && rpc) {
-    rpc.setActivity(idleStatus);
-  } else if (rpc) {
-    const currentSeconds = timeToSeconds(mediaInfo.current.split(":"));
-    const durationSeconds = timeToSeconds(mediaInfo.duration.split(":"));
-    const date = new Date();
-    const now = (date.getTime() / 1000) | 0;
-    const remaining = date.setSeconds(date.getSeconds() + (durationSeconds - currentSeconds));
-    const detailsPrefix =
-      settingsStore.get<string, string>(settings.discord.detailsPrefix) ?? "Listening to ";
-    const buttonText =
-      settingsStore.get<string, string>(settings.discord.buttonText) ?? "Play on TIDAL";
-    const includeTimestamps =
-      settingsStore.get<string, boolean>(settings.discord.includeTimestamps) ?? true;
-
-    let activity = {
-      ...idleStatus,
-      ...{
-        startTimestamp: includeTimestamps ? now : undefined,
-        endTimestamp: includeTimestamps ? remaining : undefined,
-      },
-    };
-    if (mediaInfo.url) {
-      activity = {
-        ...activity,
-        ...{
-          details: `${detailsPrefix}${mediaInfo.title}`,
-          state: mediaInfo.artists ? mediaInfo.artists : "unknown artist(s)",
-          largeImageKey: mediaInfo.image,
-          largeImageText: mediaInfo.album ? mediaInfo.album : `${idleStatus.largeImageText}`,
-          buttons: [{ label: buttonText, url: mediaInfo.url }],
-        },
-      };
-    } else {
-      activity = {
-        ...activity,
-        ...{
-          details: `Watching ${mediaInfo.title}`,
-          state: mediaInfo.artists,
-        },
-      };
-    }
-
-    rpc.setActivity(activity);
+  if (rpc) {
+    rpc.setActivity(getActivity());
   }
 };
+const getActivity = (): Presence | undefined => {
+  const presence: Presence | undefined = {
+    largeImageKey: "tidal-hifi-icon",
+    largeImageText: `TIDAL Hi-Fi ${app.getVersion()}`,
+    instance: false,
+  };
+  if (mediaInfo.status === MediaStatus.paused) {
+    presence.details = settingsStore.get<string, string>(settings.discord.idleText) ?? "Browsing Tidal";
+  } else {
+    const showSong = settingsStore.get<string, boolean>(settings.discord.showSong) ?? false;
+    if (showSong) {
+      const includeTimestamps =
+        settingsStore.get<string, boolean>(settings.discord.includeTimestamps) ?? true;
 
-const idleStatus = {
-  details: `Browsing Tidal`,
-  largeImageKey: "tidal-hifi-icon",
-  largeImageText: `TIDAL Hi-Fi ${app.getVersion()}`,
-  instance: false,
+      if (includeTimestamps) {
+        const currentSeconds = timeToSeconds(mediaInfo.current.split(":"));
+        const durationSeconds = timeToSeconds(mediaInfo.duration.split(":"));
+        const date = new Date();
+        const now = (date.getTime() / 1000) | 0;
+        const remaining = date.setSeconds(date.getSeconds() + (durationSeconds - currentSeconds));
+        presence.startTimestamp = now;
+        presence.endTimestamp = remaining;
+      }
+
+      const detailsPrefix = settingsStore.get<string, string>(settings.discord.detailsPrefix) ?? "Listening to ";
+      const buttonText = settingsStore.get<string, string>(settings.discord.buttonText) ?? "Play on TIDAL";
+
+      if (mediaInfo.url) {
+        presence.details = `${detailsPrefix}${mediaInfo.title}`;
+        presence.state = mediaInfo.artists ? mediaInfo.artists : "unknown artist(s)";
+        presence.largeImageKey = mediaInfo.image;
+        if (mediaInfo.album) {
+          presence.largeImageText = mediaInfo.album;
+        }
+        presence.buttons = [{ label: buttonText, url: mediaInfo.url }];
+      } else {
+        presence.details = `Watching ${mediaInfo.title}`;
+        presence.state = mediaInfo.artists;
+      }
+    } else {
+      presence.details = settingsStore.get<string, string>(settings.discord.listeningText) ?? "Listening Tidal";
+    }
+  }
+  return presence;
 };
 
 /**
@@ -80,7 +76,7 @@ export const initRPC = () => {
   rpc.login({ clientId }).then(
     () => {
       rpc.on("ready", () => {
-        rpc.setActivity(idleStatus);
+        rpc.setActivity(getActivity());
       });
       ipcMain.on(globalEvents.updateInfo, observer);
     },

--- a/src/scripts/discord.ts
+++ b/src/scripts/discord.ts
@@ -22,50 +22,69 @@ const observer = () => {
     rpc.setActivity(getActivity());
   }
 };
-const getActivity = (): Presence | undefined => {
-  const presence: Presence | undefined = {
-    largeImageKey: "tidal-hifi-icon",
-    largeImageText: `TIDAL Hi-Fi ${app.getVersion()}`,
-    instance: false,
-  };
+
+const defaultPresence = {
+  largeImageKey: "tidal-hifi-icon",
+  largeImageText: `TIDAL Hi-Fi ${app.getVersion()}`,
+  instance: false,
+};
+
+const getActivity = (): Presence => {
+  const presence: Presence = { ...defaultPresence };
+
   if (mediaInfo.status === MediaStatus.paused) {
-    presence.details = settingsStore.get<string, string>(settings.discord.idleText) ?? "Browsing Tidal";
+    presence.details =
+      settingsStore.get<string, string>(settings.discord.idleText) ?? "Browsing Tidal";
   } else {
     const showSong = settingsStore.get<string, boolean>(settings.discord.showSong) ?? false;
     if (showSong) {
-      const includeTimestamps =
-        settingsStore.get<string, boolean>(settings.discord.includeTimestamps) ?? true;
-
-      if (includeTimestamps) {
-        const currentSeconds = timeToSeconds(mediaInfo.current.split(":"));
-        const durationSeconds = timeToSeconds(mediaInfo.duration.split(":"));
-        const date = new Date();
-        const now = (date.getTime() / 1000) | 0;
-        const remaining = date.setSeconds(date.getSeconds() + (durationSeconds - currentSeconds));
-        presence.startTimestamp = now;
-        presence.endTimestamp = remaining;
-      }
-
-      const detailsPrefix = settingsStore.get<string, string>(settings.discord.detailsPrefix) ?? "Listening to ";
-      const buttonText = settingsStore.get<string, string>(settings.discord.buttonText) ?? "Play on TIDAL";
-
-      if (mediaInfo.url) {
-        presence.details = `${detailsPrefix}${mediaInfo.title}`;
-        presence.state = mediaInfo.artists ? mediaInfo.artists : "unknown artist(s)";
-        presence.largeImageKey = mediaInfo.image;
-        if (mediaInfo.album) {
-          presence.largeImageText = mediaInfo.album;
-        }
-        presence.buttons = [{ label: buttonText, url: mediaInfo.url }];
-      } else {
-        presence.details = `Watching ${mediaInfo.title}`;
-        presence.state = mediaInfo.artists;
-      }
+      const { includeTimestamps, detailsPrefix, buttonText } = getFromStore();
+      includeTimeStamps(includeTimestamps);
+      setPresenceFromMediaInfo(detailsPrefix, buttonText);
     } else {
-      presence.details = settingsStore.get<string, string>(settings.discord.listeningText) ?? "Listening Tidal";
+      presence.details =
+        settingsStore.get<string, string>(settings.discord.usingText) ?? "Playing media on TIDAL";
     }
   }
   return presence;
+
+  function getFromStore() {
+    const includeTimestamps =
+      settingsStore.get<string, boolean>(settings.discord.includeTimestamps) ?? true;
+    const detailsPrefix =
+      settingsStore.get<string, string>(settings.discord.detailsPrefix) ?? "Listening to ";
+    const buttonText =
+      settingsStore.get<string, string>(settings.discord.buttonText) ?? "Play on TIDAL";
+
+    return { includeTimestamps, detailsPrefix, buttonText };
+  }
+
+  function setPresenceFromMediaInfo(detailsPrefix: any, buttonText: any) {
+    if (mediaInfo.url) {
+      presence.details = `${detailsPrefix}${mediaInfo.title}`;
+      presence.state = mediaInfo.artists ? mediaInfo.artists : "unknown artist(s)";
+      presence.largeImageKey = mediaInfo.image;
+      if (mediaInfo.album) {
+        presence.largeImageText = mediaInfo.album;
+      }
+      presence.buttons = [{ label: buttonText, url: mediaInfo.url }];
+    } else {
+      presence.details = `Watching ${mediaInfo.title}`;
+      presence.state = mediaInfo.artists;
+    }
+  }
+
+  function includeTimeStamps(includeTimestamps: any) {
+    if (includeTimestamps) {
+      const currentSeconds = timeToSeconds(mediaInfo.current.split(":"));
+      const durationSeconds = timeToSeconds(mediaInfo.duration.split(":"));
+      const date = new Date();
+      const now = (date.getTime() / 1000) | 0;
+      const remaining = date.setSeconds(date.getSeconds() + (durationSeconds - currentSeconds));
+      presence.startTimestamp = now;
+      presence.endTimestamp = remaining;
+    }
+  }
 };
 
 /**

--- a/src/scripts/settings.ts
+++ b/src/scripts/settings.ts
@@ -19,6 +19,9 @@ export const settingsStore = new Store({
     enableCustomHotkeys: false,
     enableDiscord: false,
     discord: {
+      showSong: false,
+      idleText: "Browsing Tidal",
+      listeningText: "Listening Tidal",
       detailsPrefix: "Listening to ",
       buttonText: "Play on Tidal",
       includeTimestamps: true,

--- a/src/scripts/settings.ts
+++ b/src/scripts/settings.ts
@@ -5,6 +5,25 @@ import path from "path";
 import { settings } from "../constants/settings";
 
 let settingsWindow: BrowserWindow;
+/**
+ * Build a migration step for several settings.
+ * All settings will be checked and set to the default if non-existent.
+ * @param version
+ * @param migrationStore
+ * @param options
+ */
+const buildMigration = (
+  version: string,
+  migrationStore: { get: (str: string) => string; set: (str: string, val: unknown) => void },
+  options: Array<{ key: string; value: unknown }>
+) => {
+  console.log(`running migrations for ${version}`);
+  options.forEach(({ key, value }) => {
+    const valueToSet = migrationStore.get(key) ?? value;
+    console.log(`  - setting ${key} to ${value}`);
+    migrationStore.set(key, valueToSet);
+  });
+};
 
 export const settingsStore = new Store({
   defaults: {
@@ -19,12 +38,12 @@ export const settingsStore = new Store({
     enableCustomHotkeys: false,
     enableDiscord: false,
     discord: {
-      showSong: false,
+      showSong: true,
       idleText: "Browsing Tidal",
-      listeningText: "Listening Tidal",
+      usingText: "Playing media on TIDAL",
+      includeTimestamps: true,
       detailsPrefix: "Listening to ",
       buttonText: "Play on Tidal",
-      includeTimestamps: true,
     },
     ListenBrainz: {
       enabled: false,
@@ -71,6 +90,16 @@ export const settingsStore = new Store({
         settings.discord.includeTimestamps,
         migrationStore.get(settings.discord.includeTimestamps) ?? true
       );
+    },
+    "5.9.0": (migrationStore) => {
+      buildMigration("5.9.0", migrationStore, [
+        { key: settings.discord.showSong, value: "true" },
+        { key: settings.discord.idleText, value: "Browsing Tidal" },
+        {
+          key: settings.discord.usingText,
+          value: "Playing media on TIDAL",
+        },
+      ]);
     },
   },
 });


### PR DESCRIPTION
This PR adds two features to enhance the user's control over the discord integration:

- The ability to hide the current song from the discord activity and display a custom text instead
- The ability to customize the text that is shown when no song is playing

## Detailed description

To implement these features, this PR introduces three new settings in the `discord` section of the configuration:

- `showSong` (boolean): This setting determines whether the current song is shown in the discord activity or not. If set to `true`, the current song will be displayed as usual. If set to `false`, the custom text specified by the `listeningText` setting will be shown instead.
- `idleText` (string): This setting specifies the text that is shown in the discord activity when no song is playing. The default value is `Browsing Tidal`.
- `listeningText` (string): This setting specifies the text that is shown in the discord activity when a song is playing and the `showSong` setting is set to `false`. The default value is `Listening Tidal`.

To handle the different scenarios, this PR also introduces a new function in `src/scripts/discord.ts`:

- `getActivity`: This function returns the appropriate `Presence` object based on the current song and the settings. It is used by the other functions in the same file to update the discord activity.

This PR does not include a migration for the storage, as it is uncertain when or if this code will be merged.

I would like to thank the owners and contributors of this project for creating and maintaining this awesome project. I hope this PR will be useful and welcome.