### PR TITLE
feature: Track current notification to replace it on track change

### DIFF
--- a/src/preload.ts
+++ b/src/preload.ts
@@ -28,6 +28,7 @@ let currentListenBrainzDelayId: ReturnType<typeof setTimeout>;
 let scrobbleWaitingForDelay = false;
 let wasJustPausedOrResumed = false;
 let currentMediaInfo: Options;
+let currentNotification: Electron.Notification;
 
 const elements = {
   play: '*[data-test="play"]',
@@ -359,7 +360,9 @@ function updateMediaInfo(options: Options, notify: boolean) {
     currentMediaInfo = options;
     ipcRenderer.send(globalEvents.updateInfo, options);
     if (settingsStore.get(settings.notifications) && notify) {
-      new Notification({ title: options.title, body: options.artists, icon: options.icon }).show();
+      if (currentNotification) currentNotification.close();
+      currentNotification = new Notification({ title: options.title, body: options.artists, icon: options.icon });
+      currentNotification.show();
     }
     updateMpris(options);
     updateListenBrainz(options);


### PR DESCRIPTION
This change closes the previous notification if a new one comes up.
Before my notifications would get spammed full when the title changes. :)