### PR TITLE
Api Feature: Add shuffle and repeat state to API

### DIFF
--- a/src/models/mediaInfo.ts
+++ b/src/models/mediaInfo.ts
@@ -1,4 +1,5 @@
 import { MediaStatus } from "./mediaStatus";
+import {MediaPlayerInfo} from "./mediaPlayerInfo";
 
 export interface MediaInfo {
   title: string;
@@ -13,4 +14,5 @@ export interface MediaInfo {
   durationInSeconds?: number;
   image: string;
   favorite: boolean;
+  player: MediaPlayerInfo;
 }

--- a/src/models/mediaInfo.ts
+++ b/src/models/mediaInfo.ts
@@ -1,5 +1,5 @@
 import { MediaStatus } from "./mediaStatus";
-import {MediaPlayerInfo} from "./mediaPlayerInfo";
+import { MediaPlayerInfo } from "./mediaPlayerInfo";
 
 export interface MediaInfo {
   title: string;

--- a/src/models/mediaPlayerInfo.ts
+++ b/src/models/mediaPlayerInfo.ts
@@ -1,0 +1,8 @@
+import {RepeatState} from "./repeatState";
+import {MediaStatus} from "./mediaStatus";
+
+export interface MediaPlayerInfo {
+  status: MediaStatus;
+  shuffle: boolean;
+  repeat: RepeatState;
+}

--- a/src/models/mediaPlayerInfo.ts
+++ b/src/models/mediaPlayerInfo.ts
@@ -1,5 +1,5 @@
-import {RepeatState} from "./repeatState";
-import {MediaStatus} from "./mediaStatus";
+import { RepeatState } from "./repeatState";
+import { MediaStatus } from "./mediaStatus";
 
 export interface MediaPlayerInfo {
   status: MediaStatus;

--- a/src/models/repeatState.ts
+++ b/src/models/repeatState.ts
@@ -1,0 +1,5 @@
+export enum RepeatState {
+  off = "off",
+  all = "all",
+  single = "single",
+}

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -19,7 +19,7 @@ import { downloadFile } from "./scripts/download";
 import { addHotkey } from "./scripts/hotkeys";
 import { settingsStore } from "./scripts/settings";
 import { setTitle } from "./scripts/window-functions";
-import {RepeatState} from "./models/repeatState";
+import { RepeatState } from "./models/repeatState";
 
 const notificationPath = `${app.getPath("userData")}/notification.jpg`;
 const appName = "TIDAL Hi-Fi";

--- a/src/scripts/mediaInfo.ts
+++ b/src/scripts/mediaInfo.ts
@@ -1,5 +1,6 @@
 import { MediaInfo } from "../models/mediaInfo";
 import { MediaStatus } from "../models/mediaStatus";
+import {RepeatState} from "../models/repeatState";
 
 export const mediaInfo = {
   title: "",
@@ -14,6 +15,12 @@ export const mediaInfo = {
   durationInSeconds: 0,
   image: "tidal-hifi-icon",
   favorite: false,
+
+  player: {
+    status: MediaStatus.paused as string,
+    shuffle: false,
+    repeat: RepeatState.off as string,
+  }
 };
 
 export const updateMediaInfo = (arg: MediaInfo) => {
@@ -29,6 +36,10 @@ export const updateMediaInfo = (arg: MediaInfo) => {
   mediaInfo.durationInSeconds = arg.durationInSeconds ?? 0;
   mediaInfo.image = propOrDefault(arg.image);
   mediaInfo.favorite = arg.favorite;
+
+  mediaInfo.player.status = propOrDefault(arg.player?.status);
+  mediaInfo.player.shuffle = arg.player.shuffle;
+  mediaInfo.player.repeat = propOrDefault(arg.player?.repeat);
 };
 
 /**

--- a/src/scripts/mediaInfo.ts
+++ b/src/scripts/mediaInfo.ts
@@ -1,6 +1,6 @@
 import { MediaInfo } from "../models/mediaInfo";
 import { MediaStatus } from "../models/mediaStatus";
-import {RepeatState} from "../models/repeatState";
+import { RepeatState } from "../models/repeatState";
 
 export const mediaInfo = {
   title: "",


### PR DESCRIPTION
This PR adds the shuffle and repeat state to the API for external applications to know what the current state is for display purposes. Ie. #393 