### PR TITLE
Fix issue #449 Discord RPC stuck on "Browsing Tidal"

### DIFF
--- a/src/scripts/discord.ts
+++ b/src/scripts/discord.ts
@@ -60,7 +60,12 @@ const getActivity = (): Presence => {
       presence.state = mediaInfo.artists ? mediaInfo.artists : "unknown artist(s)";
       presence.largeImageKey = mediaInfo.image;
       if (mediaInfo.album) {
-        presence.largeImageText = mediaInfo.album;
+        if (mediaInfo.album.length < 2) {  // Fix for DiscordRPC 2 character minimum
+          presence.largeImageText = mediaInfo.album + " ";
+        }
+        else {
+          presence.largeImageText = mediaInfo.album;
+        }
       }
       presence.buttons = [{ label: buttonText, url: mediaInfo.url }];
     } else {


### PR DESCRIPTION
# Fix for #449 

**`/src/scripts/discord.ts:62`**
```ts
if (mediaInfo.album) {
        if (mediaInfo.album.length < 2) {  // Fix for DiscordRPC 2 character minimum
          presence.largeImageText = mediaInfo.album + " ";
        }
        else {
          presence.largeImageText = mediaInfo.album;
        }
      }
```

Discord API doesn't like largeImageTexts with less than 2 characters, so to fix this issue I've added an extra space to the album name, which Discord automatically trims as trailing white-space anyway.

![image](https://github.com/user-attachments/assets/e968a44d-f192-4b68-8462-e0dade86db1e)
