### PR TITLE
Fix Discord RPC timestamp jitter.

### DIFF
--- a/src/scripts/discord.ts
+++ b/src/scripts/discord.ts
@@ -38,6 +38,9 @@ const updateActivity = () => {
   }
 };
 
+let prevEndTimestamp = 0;
+let prevStartTimestamp = 0;
+
 const getActivity = (): SetActivity => {
   const presence: SetActivity = { ...defaultPresence };
 
@@ -103,11 +106,11 @@ const getActivity = (): SetActivity => {
     if (includeTimestamps) {
       const currentSeconds = convertDurationToSeconds(mediaInfo.current);
       const durationSeconds = convertDurationToSeconds(mediaInfo.duration);
-      const date = new Date();
-      const now = Math.floor(date.getTime() / 1000);
+      const now = Math.trunc(Date.now() / 1000);
+
       presence.startTimestamp = now - currentSeconds;
       presence.endTimestamp = presence.startTimestamp + durationSeconds;
-    }
+    } 
   }
 };
 


### PR DESCRIPTION
The timestamp was changing every second due to how time is being rounded (this is my theory).

Added logic to prevent this and timestamps will only change if the change is substantial. (for ex: when the song changes)

Probably needs some refactoring? It feels like spaghetti code to me for some reason but I need ideas on how to make it better.