### PR TITLE
Fix Discord RPC Timestamp jitter

### DIFF
--- a/src/scripts/discord.ts
+++ b/src/scripts/discord.ts
@@ -103,8 +103,7 @@ const getActivity = (): SetActivity => {
     if (includeTimestamps) {
       const currentSeconds = convertDurationToSeconds(mediaInfo.current);
       const durationSeconds = convertDurationToSeconds(mediaInfo.duration);
-      const date = new Date();
-      const now = Math.floor(date.getTime() / 1000);
+      const now = Math.trunc((Date.now() + 500) / 1000);
       presence.startTimestamp = now - currentSeconds;
       presence.endTimestamp = presence.startTimestamp + durationSeconds;
     }


### PR DESCRIPTION
The problem exists in the timing between the mediaInfo updates and the Date.now(), they had a 500 ms difference.
This offsets the Date.now by that difference and gets rid of the jitter while the song is playing.

The jitter still exists when jumping around the song or when a song starts but it stabilizes quickly.