### PR TITLE
feat(build): Update Wayland launch flags for Linux

### DIFF
--- a/build/electron-builder.base.yml
+++ b/build/electron-builder.base.yml
@@ -17,9 +17,9 @@ linux:
   executableName: tidal-hifi
   executableArgs:
     [
-      "--enable-features=UseOzonePlatform",
       "--ozone-platform-hint=auto",
       "--enable-features=WaylandWindowDecorations",
+      "--enable-wayland-ime",
     ]
   desktop:
     entry:


### PR DESCRIPTION
- Removes the `--enable-features=UseOzonePlatform` flag, as the Ozone platform has been the default on Linux since Electron 28 and this flag is no longer necessary.

- Adds the `--enable-wayland-ime` flag to enable Input Method Editor (IME) support in Wayland environments, improving the input experience for CJK and other users.
