### PR TITLE
feat: shows artists names in status on discord presence

### DIFF
--- a/src/scripts/discord.ts
+++ b/src/scripts/discord.ts
@@ -85,6 +85,7 @@ const getActivity = (): SetActivity => {
     const artists = pad(mediaInfo.artists);
 
     if (mediaInfo.url) {
+      presence.statusDisplayType = 1;
       presence.details = `${detailsPrefix}${title}`;
       presence.state = artists ? artists : "unknown artist(s)";
       presence.largeImageKey = mediaInfo.image;


### PR DESCRIPTION
Display artist names in Discord Rich Presence (like Spotify).

Before:
<img width="228" height="76" alt="image" src="https://github.com/user-attachments/assets/fbf6b440-bce5-463d-8064-bfd4565e898e" />

After:
<img width="248" height="72" alt="image" src="https://github.com/user-attachments/assets/7e60f208-afec-42ea-8db9-6c8ae6623c54" />
