### PR TITLE
Set the default TIDAL URL to https://tidal.com/ to avoid redirect failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![GitHub release](https://img.shields.io/github/release/Mastermindzh/tidal-hifi.svg) [![github builds](https://github.com/mastermindzh/tidal-hifi/actions/workflows/build.yml/badge.svg)](https://github.com/Mastermindzh/tidal-hifi/actions) [![Build Status](https://ci.mastermindzh.tech/api/badges/Mastermindzh/tidal-hifi/status.svg)](https://ci.mastermindzh.tech/Mastermindzh/tidal-hifi) [![Discord logo](./docs/images/discord.png)](https://discord.gg/yhNwf4v4He)
 
-The web version of [listen.tidal.com](https://listen.tidal.com) running in electron with Hi-Fi (High & Max) support thanks to widevine.
+The web version of [TIDAL](https://tidal.com) running in electron with Hi-Fi (High & Max) support thanks to widevine.
 
 ![TIDAL Hi-Fi preview](./docs/images/preview.png)
 

--- a/build/electron-builder.base.yml
+++ b/build/electron-builder.base.yml
@@ -27,7 +27,7 @@ linux:
       Encoding: "UTF-8"
       Name: "TIDAL Hi-Fi"
       GenericName: "TIDAL Hi-Fi"
-      Comment: "The web version of listen.tidal.com running in electron with hifi support thanks to widevine."
+      Comment: "The web version of TIDAL running in electron with hifi support thanks to widevine."
       Icon: "tidal-hifi"
       StartupNotify: "true"
       Terminal: "false"

--- a/src/features/listenbrainz/listenbrainz.ts
+++ b/src/features/listenbrainz/listenbrainz.ts
@@ -5,6 +5,7 @@ import { MediaStatus } from "../../models/mediaStatus";
 import { settingsStore } from "../../scripts/settings";
 import { Logger } from "../logger";
 import { StoreData } from "./models/storeData";
+import { tidalUrl } from "../../main";
 
 const ListenBrainzStore = new Store({ name: "listenbrainz" });
 
@@ -48,9 +49,6 @@ export class ListenBrainz {
       } else {
         // Fetches the oldData required for scrobbling and proceeds to construct a playing_now data payload for the Playing Now area
         const oldData = ListenBrainzStore.get(ListenBrainzConstants.oldData) as StoreData;
-        const tidalUrl =
-          settingsStore.get<string, string>(settings.advanced.tidalUrl) ||
-          "https://listen.tidal.com";
         const playing_data = {
           listen_type: "playing_now",
           payload: [

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,7 +38,7 @@ const windowPreferences = {
 setDefaultFlags(app);
 setManagedFlagsFromSettings(app);
 
-const tidalUrl =
+export const tidalUrl =
   settingsStore.get<string, string>(settings.advanced.tidalUrl) || "https://tidal.com";
 
 /**
@@ -183,7 +183,7 @@ app.on("ready", async () => {
 
     // Adblock
     if (settingsStore.get(settings.adBlock)) {
-      const filter = { urls: ["https://listen.tidal.com/*"] };
+      const filter = { urls: [tidalUrl + "/*"] };
       session.defaultSession.webRequest.onBeforeRequest(filter, (details, callback) => {
         if (details.url.match(/\/users\/.*\d\?country/)) callback({ cancel: true });
         else callback({ cancel: false });

--- a/src/pages/settings/settings.html
+++ b/src/pages/settings/settings.html
@@ -368,8 +368,8 @@
                   <strong>note! Beta might break at any time</strong>
                 </p>
                 <select class="select-input" id="channel" name="channel">
-                  <option value="https://listen.tidal.com">Stable (listen.tidal.com)</option>
-                  <option value="https://listen.stage.tidal.com">Staging (listen.stage.tidal.com)</option>
+                  <option value="https://tidal.com">Stable (tidal.com)</option>
+                  <option value="https://stage.tidal.com">Staging (stage.tidal.com)</option>
                 </select>
               </div>
             </div>

--- a/src/scripts/settings.ts
+++ b/src/scripts/settings.ts
@@ -29,7 +29,7 @@ export const settingsStore = new Store({
   defaults: {
     adBlock: false,
     advanced: {
-      tidalUrl: "https://listen.tidal.com",
+      tidalUrl: "https://tidal.com",
     },
     api: true,
     apiSettings: {


### PR DESCRIPTION
This pull request makes a minor update to the default TIDAL URL used in the application settings. The default value has been changed from "https://listen.tidal.com" to "https://tidal.com" as mentioned in #772.