### PR TITLE
fix: change transparency setting based on platform

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -148,7 +148,7 @@ function createWindow(options = { x: 0, y: 0, backgroundColor: "white" }) {
     icon,
     backgroundColor: options.backgroundColor,
     autoHideMenuBar: true,
-    transparent: true,
+    transparent: process.platform !== "darwin",
     webPreferences: {
       ...windowPreferences,
       ...{


### PR DESCRIPTION
Sets the `transparent` property of the window object to false if current platform is darwin (MacOS).

Fixes issue where a macos build does not have a visible title bar.