### PR TITLE
fix: register isQuitting handler unconditionally to fix tray quit

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -199,11 +199,9 @@ function createWindow(options = { x: 0, y: 0, backgroundColor: "white" }) {
     mainWindow.webContents.setBackgroundThrottling(false);
   }
 
-  if (!app.listenerCount("before-quit")) {
-    app.on("before-quit", () => {
-      isQuitting = true;
-    });
-  }
+  app.on("before-quit", () => {
+    isQuitting = true;
+  });
 
   mainWindow.on("close", (event: CloseEvent) => {
     if (!isQuitting && settingsStore.get(settings.minimizeOnClose)) {


### PR DESCRIPTION
## Bug
https://github.com/Mastermindzh/tidal-hifi/issues/885 — Closing via tray icon leaves the process running because the window hides instead of closing.

## Root Cause
The `before-quit` listener registered at module scope (line 325, for cleanup) was already counted when `createWindow()` ran. The guard `!app.listenerCount("before-quit")` therefore evaluated to `false`, preventing the `isQuitting = true` handler from ever being registered.

When `app.quit()` was called from the tray context menu, Electron emitted `before-quit` but `isQuitting` stayed `false`. The window's `close` handler then called `event.preventDefault()` and hid the window instead of letting it close — leaving a zombie process.

## Fix
Remove the `listenerCount` guard so the `isQuitting = true` handler is always registered inside `createWindow()`. Multiple `before-quit` listeners are harmless and expected in Electron.

## Testing
Verified the listener registration flow:
- Module-level `before-quit` (cleanup) registers first
- `createWindow()` now unconditionally adds the `isQuitting = true` listener
- Tray quit → `app.quit()` → `before-quit` fires → `isQuitting = true` → window `close` handler allows close → `closed` handler calls `gracefulExit()`

Happy to address any feedback.

Greetings, saschabuehrle