### PR TITLE
feat: auto-hide scrollbars while scrolling

### DIFF
--- a/src/constants/settings.ts
+++ b/src/constants/settings.ts
@@ -55,6 +55,7 @@ export const settings = {
   hotkeys: {
     root: "hotkeys",
   },
+  autoHideScrollbars: "autoHideScrollbars",
   menuBar: "menuBar",
   minimizeOnClose: "minimizeOnClose",
   mpris: "mpris",

--- a/src/features/theming/theming.ts
+++ b/src/features/theming/theming.ts
@@ -2,8 +2,118 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { settings } from "../../constants/settings";
-import { settingsStore } from "../../scripts/settings";
+import { getAutoHideScrollbarsSetting, settingsStore } from "../../scripts/settings";
 import { Logger } from "../logger";
+
+const AUTO_HIDE_SCROLLBARS_CSS = `
+html.tidal-hifi-auto-hide-scrollbars body:not(.settings-window),
+html.tidal-hifi-auto-hide-scrollbars body:not(.settings-window) * {
+  -ms-overflow-style: none;
+  scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
+}
+
+html.tidal-hifi-auto-hide-scrollbars body:not(.settings-window)::-webkit-scrollbar,
+html.tidal-hifi-auto-hide-scrollbars body:not(.settings-window) *::-webkit-scrollbar {
+  width: 6px !important;
+  height: 6px !important;
+}
+
+html.tidal-hifi-auto-hide-scrollbars body:not(.settings-window)::-webkit-scrollbar-track,
+html.tidal-hifi-auto-hide-scrollbars body:not(.settings-window) *::-webkit-scrollbar-track {
+  background-color: transparent !important;
+}
+
+html.tidal-hifi-auto-hide-scrollbars body:not(.settings-window)::-webkit-scrollbar-thumb,
+html.tidal-hifi-auto-hide-scrollbars body:not(.settings-window) *::-webkit-scrollbar-thumb {
+  background-color: transparent !important;
+  border-radius: 3px !important;
+}
+
+html.tidal-hifi-auto-hide-scrollbars.tidal-hifi-scrollbars-visible body:not(.settings-window),
+html.tidal-hifi-auto-hide-scrollbars.tidal-hifi-scrollbars-visible body:not(.settings-window) * {
+  scrollbar-color: rgba(255, 255, 255, 0.32) transparent;
+}
+
+html.tidal-hifi-auto-hide-scrollbars.tidal-hifi-scrollbars-visible body:not(.settings-window)::-webkit-scrollbar-thumb,
+html.tidal-hifi-auto-hide-scrollbars.tidal-hifi-scrollbars-visible body:not(.settings-window) *::-webkit-scrollbar-thumb {
+  background-color: rgba(255, 255, 255, 0.32) !important;
+}
+
+html.tidal-hifi-auto-hide-scrollbars body:not(.settings-window) .os-scrollbar {
+  opacity: 0 !important;
+  pointer-events: none !important;
+  transition: opacity 160ms ease-out;
+}
+
+html.tidal-hifi-auto-hide-scrollbars.tidal-hifi-scrollbars-visible body:not(.settings-window) .os-scrollbar {
+  opacity: 1 !important;
+}
+`;
+
+const AUTO_HIDE_SCROLLBARS_SCRIPT = `(() => {
+  if (document.body?.classList.contains("settings-window")) {
+    return;
+  }
+
+  if (window.__tidalHifiAutoHideScrollbarsInitialized) {
+    return;
+  }
+
+  window.__tidalHifiAutoHideScrollbarsInitialized = true;
+
+  const root = document.documentElement;
+  if (!root) {
+    return;
+  }
+
+  const visibleClass = "tidal-hifi-scrollbars-visible";
+  const enabledClass = "tidal-hifi-auto-hide-scrollbars";
+  const hideDelayMs = 1400;
+  let hideTimer;
+
+  const hideScrollbars = () => {
+    root.classList.remove(visibleClass);
+  };
+
+  const scheduleHide = () => {
+    window.clearTimeout(hideTimer);
+    hideTimer = window.setTimeout(hideScrollbars, hideDelayMs);
+  };
+
+  const showScrollbars = () => {
+    root.classList.add(enabledClass);
+    root.classList.add(visibleClass);
+    scheduleHide();
+  };
+
+  const onKeyDown = (event) => {
+    const scrollKeys = new Set([
+      "ArrowDown",
+      "ArrowUp",
+      "ArrowLeft",
+      "ArrowRight",
+      "PageDown",
+      "PageUp",
+      "Home",
+      "End",
+      "Space",
+    ]);
+
+    if (scrollKeys.has(event.code) || scrollKeys.has(event.key)) {
+      showScrollbars();
+    }
+  };
+
+  root.classList.add(enabledClass);
+  scheduleHide();
+
+  window.addEventListener("scroll", showScrollbars, { capture: true, passive: true });
+  window.addEventListener("wheel", showScrollbars, { passive: true });
+  window.addEventListener("touchmove", showScrollbars, { passive: true });
+  window.addEventListener("keydown", onKeyDown);
+  window.addEventListener("blur", hideScrollbars);
+})();`;
 
 /**
  * Parse a theme identifier into its source and filename.
@@ -84,5 +194,12 @@ export function injectThemeCss(
   const customCSS = settingsStore.get<string, string[]>(settings.customCSS);
   if (customCSS?.length) {
     webContents.insertCSS(customCSS.join("\n"));
+  }
+
+  if (getAutoHideScrollbarsSetting()) {
+    webContents.insertCSS(AUTO_HIDE_SCROLLBARS_CSS);
+    void webContents.executeJavaScript(AUTO_HIDE_SCROLLBARS_SCRIPT).catch((error) => {
+      Logger.log("Failed to inject auto-hide scrollbar behavior.", error);
+    });
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -380,8 +380,12 @@ ipcMain.on(globalEvents.refreshMenuBar, () => {
   syncMenuBarWithStore();
 });
 
-ipcMain.on(globalEvents.storeChanged, () => {
+ipcMain.on(globalEvents.storeChanged, (_event, changedKey?: string) => {
   syncMenuBarWithStore();
+
+  if (changedKey === settings.autoHideScrollbars) {
+    mainWindow.webContents.reload();
+  }
 
   if (settingsStore.get(settings.enableDiscord) && !rpc) {
     initRPC();

--- a/src/pages/settings/preload.ts
+++ b/src/pages/settings/preload.ts
@@ -7,7 +7,7 @@ import { globalEvents } from "../../constants/globalEvents";
 import { settings } from "../../constants/settings";
 import { SUPPORTED_TRAY_ICON_EXTENSIONS } from "../../constants/trayIcon";
 import { Logger } from "../../features/logger";
-import { settingsStore } from "../../scripts/settings";
+import { getAutoHideScrollbarsSetting, settingsStore } from "../../scripts/settings";
 import { initializeHotkeys } from "./hotkeys";
 import { cssFilter, getOptions, getOptionsHeader, getThemeListFromDirectory } from "./theming";
 
@@ -57,6 +57,7 @@ let adBlock: HTMLInputElement,
   enableCustomHotkeys: HTMLInputElement,
   enableDiscord: HTMLInputElement,
   gpuRasterization: HTMLInputElement,
+  autoHideScrollbars: HTMLInputElement,
   hotkeySearch: HTMLInputElement,
   hotkeysList: HTMLElement,
   hostname: HTMLInputElement,
@@ -234,6 +235,7 @@ function refreshSettings() {
     enableDiscord.checked = settingsStore.get(settings.enableDiscord);
     enableWaylandSupport.checked = settingsStore.get(settings.flags.enableWaylandSupport);
     gpuRasterization.checked = settingsStore.get(settings.flags.gpuRasterization);
+    autoHideScrollbars.checked = getAutoHideScrollbarsSetting();
     hostname.value = settingsStore.get(settings.apiSettings.hostname);
     menuBar.checked = settingsStore.get(settings.menuBar);
     minimizeOnClose.checked = settingsStore.get(settings.minimizeOnClose);
@@ -338,21 +340,21 @@ window.addEventListener("DOMContentLoaded", () => {
           setElementHidden(source.checked, toggleOptions);
         }
       }
-      ipcRenderer.send(globalEvents.storeChanged);
+      ipcRenderer.send(globalEvents.storeChanged, key);
     });
   }
 
   function addTextAreaListener(source: HTMLInputElement, key: string) {
     source.addEventListener("input", () => {
       settingsStore.set(key, source.value.split("\n"));
-      ipcRenderer.send(globalEvents.storeChanged);
+      ipcRenderer.send(globalEvents.storeChanged, key);
     });
   }
 
   function addSelectListener(source: HTMLSelectElement, key: string) {
     source.addEventListener("change", () => {
       settingsStore.set(key, source.value);
-      ipcRenderer.send(globalEvents.storeChanged);
+      ipcRenderer.send(globalEvents.storeChanged, key);
     });
   }
 
@@ -365,7 +367,7 @@ window.addEventListener("DOMContentLoaded", () => {
 
       // Only send storeChanged if valid to avoid unnecessary reloads
       if (isValid) {
-        ipcRenderer.send(globalEvents.storeChanged);
+        ipcRenderer.send(globalEvents.storeChanged, key);
       }
     });
 
@@ -396,6 +398,7 @@ window.addEventListener("DOMContentLoaded", () => {
   enableDiscord = get("enableDiscord");
   enableWaylandSupport = get("enableWaylandSupport");
   gpuRasterization = get("gpuRasterization");
+  autoHideScrollbars = get("autoHideScrollbars");
   hotkeySearch = get("hotkey-search");
   hotkeysList = get("hotkeys-list");
   hostname = get("hostname");
@@ -442,6 +445,7 @@ window.addEventListener("DOMContentLoaded", () => {
   addInputListener(enableDiscord, settings.enableDiscord, switchesWithSettings.discord);
   addInputListener(enableWaylandSupport, settings.flags.enableWaylandSupport);
   addInputListener(gpuRasterization, settings.flags.gpuRasterization);
+  addInputListener(autoHideScrollbars, settings.autoHideScrollbars);
   addInputListener(hostname, settings.apiSettings.hostname);
   addInputListener(menuBar, settings.menuBar);
   addInputListener(minimizeOnClose, settings.minimizeOnClose);

--- a/src/pages/settings/settings.html
+++ b/src/pages/settings/settings.html
@@ -556,6 +556,19 @@
             <p class="group__title">Theming</p>
             <div class="group__option">
               <div class="group__content">
+                <h4>Auto-hide scrollbars</h4>
+                <p>
+                  Shows scrollbars while scrolling, then hides them again after a short delay.
+                  Reload TIDAL or restart the app after changing this option.
+                </p>
+              </div>
+              <label class="switch">
+                <input id="autoHideScrollbars" type="checkbox" />
+                <span class="switch__slider"></span>
+              </label>
+            </div>
+            <div class="group__option">
+              <div class="group__content">
                 <h4>Custom CSS</h4>
                 <p>
                   The css that you put in here will be injected into a style tag in the head of

--- a/src/scripts/settings.ts
+++ b/src/scripts/settings.ts
@@ -78,6 +78,7 @@ export const settingsStore = new Store({
       enableWaylandSupport: true,
       gpuRasterization: true,
     },
+    autoHideScrollbars: false,
     hotkeys: getDefaultHotkeyConfig(),
     menuBar: true,
     minimizeOnClose: false,
@@ -183,6 +184,14 @@ export const settingsStore = new Store({
     },
   },
 });
+
+export const getAutoHideScrollbarsSetting = () => {
+  return (
+    settingsStore.get<string, boolean>(settings.autoHideScrollbars) ??
+    settingsStore.get<string, boolean>("hideScrollbars") ??
+    false
+  );
+};
 
 export const createSettingsWindow = () => {
   settingsWindow = new BrowserWindow({


### PR DESCRIPTION
Closes #850

## Summary
  - add an Auto-hide scrollbars setting in the theming page
  - show scrollbars while scrolling, then hide them again after a short delay
  - reload the main window when the setting changes so the behavior applies immediately
## Verification
  - npm run compile
  - npx biome check src/constants/settings.ts src/scripts/settings.ts src/pages/settings/preload.ts src/pages/settings/settings.html src/features/theming/theming.ts src/main.ts
  - manually verified the scrollbar behavior in the app