### PR TITLE
fix: expose all credited artists in Discord and MPRIS

### DIFF
--- a/src/TidalControllers/MediaSessionController/MediaSessionController.ts
+++ b/src/TidalControllers/MediaSessionController/MediaSessionController.ts
@@ -151,12 +151,14 @@ export class MediaSessionController implements TidalController<MediaSessionContr
   }
 
   getArtists(): string[] {
-    const artist = navigator.mediaSession?.metadata?.artist;
-    return artist ? [artist] : [""];
+    // navigator.mediaSession.metadata.artist only carries the primary artist, so read the
+    // full list from the DOM instead (the footer lists every credited artist).
+    return this.fallbackDomController.getArtists();
   }
 
   getArtistsString(): string {
-    return navigator.mediaSession?.metadata?.artist || "";
+    // Join all credited artists (the MediaSession metadata exposes only the first one).
+    return this.fallbackDomController.getArtistsString();
   }
 
   getSongIcon(): string {

--- a/src/features/mpris/mprisService.ts
+++ b/src/features/mpris/mprisService.ts
@@ -263,7 +263,12 @@ export class MprisService {
         // PropertiesChanged signal, so we only do it when the track changes.
         this.player.metadata = {
           "xesam:title": mediaInfo.title || "",
-          "xesam:artist": [mediaInfo.artists || ""],
+          // xesam:artist is an array of individual artists; prefer the parsed list so GNOME
+          // shows every credited artist, falling back to the joined string when it's absent.
+          "xesam:artist":
+            mediaInfo.artistsArray && mediaInfo.artistsArray.length > 0
+              ? mediaInfo.artistsArray
+              : [mediaInfo.artists || ""],
           "xesam:album": mediaInfo.album || "",
           "xesam:url": mediaInfo.url || "",
           "mpris:artUrl": artUrl,


### PR DESCRIPTION
## What

Multi-artist tracks were only showing the **primary artist** in Discord Rich Presence and in the MPRIS/GNOME media controls.

- **Discord**: `navigator.mediaSession.metadata.artist` only carries the primary artist. `MediaSessionController` now delegates `getArtists()` / `getArtistsString()` to the DOM controller, which reads every credited artist from the player footer.
- **MPRIS**: `xesam:artist` advertised only the joined string as a single entry. It now uses the artist array when available, so GNOME and other MPRIS clients list each artist individually.

## Why

On tracks with several credited artists, both the Discord card and the GNOME media widget dropped everyone but the first artist.

## Testing

- `npx tsc --noEmit` passes
- `npm run lint` clean on changed files
- Verified manually against a 3-artist track (Discord card and GNOME widget both list all artists)