### PR TITLE
fix: read the active audio buffer for player state

### DIFF
--- a/src/TidalControllers/DomController/DomTidalController.ts
+++ b/src/TidalControllers/DomController/DomTidalController.ts
@@ -9,7 +9,13 @@ import { constrainPollingInterval } from "../../utility/pollingConstraints";
 import type { TidalController } from "../TidalController";
 import { UI_SELECTORS } from "./constants";
 import type { DomControllerOptions } from "./DomControllerOptions";
-import { clickElement, getElement, getElementAttribute, getElementText } from "./domHelpers";
+import {
+  clickElement,
+  getActivePlayer,
+  getElement,
+  getElementAttribute,
+  getElementText,
+} from "./domHelpers";
 
 export class DomTidalController implements TidalController<DomControllerOptions> {
   private updateSubscriber!: (state: Partial<MediaInfo>) => void;
@@ -22,8 +28,7 @@ export class DomTidalController implements TidalController<DomControllerOptions>
    * Get a player element
    */
   getPlayer() {
-    const player = getElement("player") as HTMLVideoElement;
-    return player || null;
+    return getActivePlayer();
   }
 
   /**

--- a/src/TidalControllers/DomController/domHelpers.ts
+++ b/src/TidalControllers/DomController/domHelpers.ts
@@ -9,6 +9,28 @@ export function getElement(key: keyof typeof UI_SELECTORS): HTMLElement | null {
 }
 
 /**
+ * Get the media element that is currently the active playback buffer.
+ *
+ * TIDAL double-buffers audio across multiple `<video>` elements (`video-one`, `video-two`, …)
+ * and alternates between them for gapless/crossfade transitions, so the active element is not
+ * always the same id. Reading a hardcoded `#video-one` therefore returns a dead buffer
+ * (`duration = NaN`, `currentTime = 0`, `volume = 0`) whenever playback has moved to another
+ * element — which is what breaks timestamps, seek position and volume. Instead pick the element
+ * that is actually playing, falling back to any element that has loaded a real duration, then
+ * to the legacy `player` selector.
+ */
+export function getActivePlayer(): HTMLMediaElement | null {
+  const players = Array.from(
+    globalThis.document.querySelectorAll<HTMLMediaElement>("video, audio"),
+  );
+  return (
+    players.find((p) => !p.paused && Number.isFinite(p.duration) && p.duration > 0) ??
+    players.find((p) => Number.isFinite(p.duration) && p.duration > 0) ??
+    (getElement("player") as HTMLMediaElement | null)
+  );
+}
+
+/**
  * Shorthand function to get the text of a dom element
  * @param key of the object selector
  */

--- a/src/TidalControllers/ReduxController/ReduxController.ts
+++ b/src/TidalControllers/ReduxController/ReduxController.ts
@@ -6,7 +6,7 @@ import type { MediaInfo } from "../../models/mediaInfo";
 import { MediaStatus } from "../../models/mediaStatus";
 import { RepeatState } from "../../models/repeatState";
 import { constrainPollingInterval } from "../../utility/pollingConstraints";
-import { getElement } from "../DomController/domHelpers";
+import { getActivePlayer } from "../DomController/domHelpers";
 import type { TidalController } from "../TidalController";
 import type { ReduxControllerOptions } from "./ReduxControllerOptions";
 import { ReduxStoreActions as Actions } from "./ReduxStoreActions";
@@ -42,8 +42,7 @@ export class ReduxController implements TidalController<ReduxControllerOptions> 
    * Get a player element
    */
   getPlayer() {
-    const player = getElement("player") as HTMLVideoElement;
-    return player || null;
+    return getActivePlayer();
   }
 
   isStoreAvailable(): boolean {

--- a/src/scripts/discord.ts
+++ b/src/scripts/discord.ts
@@ -35,16 +35,27 @@ const defaultPresence = {
  * `setActivity` ~7,200 times/hour. Each call allocates a new payload and its
  * unawaited Promise — wasted work and extra GC pressure that also bumps into
  * Discord's rate limit (5 per 20 s). Dedupe by content excluding the jittery
- * `startTimestamp`/`endTimestamp` (derived from `Date.now()`) so identical
- * activity within the same track only sends once.
+ * `startTimestamp`/`endTimestamp` *values* (derived from `Date.now()`) so identical
+ * activity within the same track only sends once — while still keying on whether the
+ * timestamps are *present*, so the corrected payload is sent when they go from absent
+ * to available at the start of a track (see `includeTimeStamps`).
+ *
+ * `lastStartTimestamp` is tracked separately so a seek/scrub still updates Discord: during
+ * steady playback `startTimestamp` (now − elapsed) stays constant, but a scrub shifts it, so
+ * we re-send when it moves beyond a small tolerance without spamming on normal ticks.
  */
 let lastActivityKey = "";
+let lastStartTimestamp: number | undefined;
+
+// Seconds the derived start timestamp can drift (rounding jitter) before we treat it as a seek.
+const SEEK_TOLERANCE_SECONDS = 2;
 
 const updateActivity = () => {
   const showIdle = settingsStore.get<string, boolean>(settings.discord.showIdle) ?? true;
   const isPausedAndHidden = mediaInfo.status === MediaStatus.paused && !showIdle;
 
   let payloadKey: string;
+  let startTimestamp: number | undefined;
   let send: () => Promise<unknown> | undefined;
 
   if (isPausedAndHidden) {
@@ -52,16 +63,25 @@ const updateActivity = () => {
     send = () => rpc?.user?.clearActivity();
   } else {
     const activity = getActivity();
+    // getActivity only ever assigns a numeric epoch; normalize the wider number | Date type.
+    startTimestamp =
+      typeof activity.startTimestamp === "number" ? activity.startTimestamp : undefined;
     payloadKey = JSON.stringify({
       ...activity,
-      startTimestamp: undefined,
-      endTimestamp: undefined,
+      // Collapse the timestamps to a presence flag: exclude their shifting values but
+      // still re-send when they appear/disappear (e.g. duration becomes known mid-track).
+      startTimestamp: activity.startTimestamp !== undefined,
+      endTimestamp: activity.endTimestamp !== undefined,
     });
     send = () => rpc?.user?.setActivity(activity);
   }
 
-  if (payloadKey === lastActivityKey) return;
+  // Re-send when the content/presence changes, or when the timeline jumps (a seek/scrub).
+  const seeked =
+    Math.abs((startTimestamp ?? 0) - (lastStartTimestamp ?? 0)) > SEEK_TOLERANCE_SECONDS;
+  if (payloadKey === lastActivityKey && !seeked) return;
   lastActivityKey = payloadKey;
+  lastStartTimestamp = startTimestamp;
 
   send()?.catch(() => {});
 };
@@ -129,9 +149,12 @@ const getActivity = (): SetActivity => {
   }
 
   function includeTimeStamps(includeTimestamps: boolean) {
-    if (includeTimestamps) {
+    const durationSeconds = mediaInfo.durationInSeconds;
+    // Skip timestamps until we have a real duration. During a track change TIDAL's media
+    // element briefly reports duration = NaN (normalized to 0 by the controller), which
+    // would otherwise emit a bogus 00:00 / 00:00 that then sticks for the whole track.
+    if (includeTimestamps && durationSeconds > 0) {
       const currentSeconds = mediaInfo.currentInSeconds;
-      const durationSeconds = mediaInfo.durationInSeconds;
       const now = Math.trunc((Date.now() + 500) / 1000);
       presence.startTimestamp = now - currentSeconds;
       presence.endTimestamp = presence.startTimestamp + durationSeconds;


### PR DESCRIPTION
## What

TIDAL's redesigned web player double-buffers audio across alternating `<video>` elements for gapless playback. The controllers hardcoded the `#video-one` selector, which frequently reads a **dead buffer** once a second track starts.

That single root cause broke several things once you skipped past the first track:

- Discord timestamps both showed `00:00`
- The progress bar disappeared
- Volume/position were read from the wrong element
- Scrubbing was not reflected

### Changes

- Add `getActivePlayer()` to `domHelpers`, which picks the `<video>`/`<audio>` element that is actually playing (falling back to any element reporting a finite, positive duration, then to the legacy selector).
- Use it from the DOM and Redux controllers' `getPlayer()`.
- In `discord.ts`, skip emitting timestamps until a real duration is known (avoids a sticky bogus `00:00`/`00:00` during track changes), and re-send activity when the derived start timestamp jumps beyond a small tolerance so scrubbing/seeking updates the presence instead of being deduplicated away.

## Why

After TIDAL's UI redesign, Rich Presence timestamps and the progress bar broke as soon as a second track played, because the fixed selector pointed at the inactive buffer.

## Testing

- `npx tsc --noEmit` passes
- `npm run lint` clean on changed files
- Verified live via the Node debugger that `getActivePlayer()` selects the playing element, and confirmed timestamps, progress bar, and live scrubbing all work across track changes