### PR TITLE
fix: make hard reload bypass cache

### DIFF
--- a/src/constants/globalEvents.ts
+++ b/src/constants/globalEvents.ts
@@ -11,6 +11,7 @@ export const globalEvents = {
   storeChanged: "storeChanged",
   error: "error",
   getUniversalLink: "getUniversalLink",
+  hardReload: "hardReload",
   log: "log",
   toggleFavorite: "toggleFavorite",
   toggleShuffle: "toggleShuffle",

--- a/src/main.ts
+++ b/src/main.ts
@@ -376,6 +376,10 @@ ipcMain.on(globalEvents.resetZoom, () => {
   mainWindow.webContents.setZoomFactor(1.0);
 });
 
+ipcMain.on(globalEvents.hardReload, (event) => {
+  event.sender.reloadIgnoringCache();
+});
+
 ipcMain.on(globalEvents.refreshMenuBar, () => {
   syncMenuBarWithStore();
 });

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -91,8 +91,7 @@ function addHotKeys() {
       handleLogout();
     });
     addHotkey(hotkeyConfig.hardReload, () => {
-      // reloading window without cache should show the update bar if applicable
-      window.location.reload();
+      ipcRenderer.send(globalEvents.hardReload);
     });
     addHotkey(hotkeyConfig.toggleRepeat, () => {
       tidalController.repeat();


### PR DESCRIPTION
## Summary

- route the existing hard-reload shortcut through the Electron main process
- use `webContents.reloadIgnoringCache()` instead of a normal renderer reload
- keep the existing shortcut and preload boundary unchanged otherwise

This gives users affected by stale TIDAL web cache a recovery path without manually deleting the entire application cache and logging in again.

Fixes #956

## Validation

- `npm run lint`
- `npx tsc --noEmit`

AI assistance was used to prepare and validate this focused change.