### PR TITLE
MacOS: Switched transparency to Vibrancy

### DIFF
--- a/src/features/windowTransparency/windowTransparency.ts
+++ b/src/features/windowTransparency/windowTransparency.ts
@@ -9,5 +9,4 @@ import { settingsStore } from "../../scripts/settingsStore";
  * settings and magazine) share this check so they stay in sync.
  */
 export const isWindowTransparencyEnabled = (): boolean =>
-  process.platform !== "darwin" &&
   Boolean(settingsStore?.get<string, boolean>(settings.windowTransparency));

--- a/src/main.ts
+++ b/src/main.ts
@@ -221,6 +221,8 @@ function createWindow({ x = 0, y = 0, backgroundColor = "white" } = {}) {
     titleBarStyle: isMac && showCustomTitlebar ? "hiddenInset" : "default",
     trafficLightPosition: isMac && showCustomTitlebar ? { x: 14, y: 13 } : undefined,
     transparent,
+    vibrancy: isMac && transparent ? "under-window" : undefined,
+    visualEffectState: isMac && transparent ? "active" : undefined,
     webPreferences: {
       ...windowPreferences,
       preload: path.join(__dirname, "preload.js"),


### PR DESCRIPTION
As transparency on MacOS doesn't work, then I'm suggesting to add this small change that would trasnparent themes make look a lot better than just not supporting it.

And Vibrancy actually means in Mac terms slightly transparent glassy look