### PR TITLE
fix: stop appending sandbox switches after startup

### DIFF
--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -54,7 +54,9 @@ For different installation methods:
 ### Advanced setting
 
 Under "Advanced" in the settings menu you'll find a section to toggle flags, there you can also toggle the sandbox flag.
-The default value of this flag is "true", which means the sandbox is disabled. Though note, this might not always work, if not use `--no-sandbox`.
+The default value of this flag is "true", which disables the renderer sandbox for the player, settings, and login windows. Restart the app after changing it.
+
+This setting does not disable Chromium's sandbox globally. If a sandbox-related startup issue persists, launch with `--no-sandbox` as shown above. Global sandbox switches must be supplied at launch: applying them from JavaScript after Linux's zygote processes have started can cause child-process crashes, including misleading `/dev/shm` permission errors.
 
 ![The flag as shown in the settings window](./images/disable-sandbox.png)
 

--- a/src/constants/flags.ts
+++ b/src/constants/flags.ts
@@ -1,7 +1,8 @@
 export const flags: { [key: string]: { flag: string; value?: string }[] } = {
   gpuRasterization: [{ flag: "enable-gpu-rasterization", value: undefined }],
   disableHardwareMediaKeys: [{ flag: "disable-features", value: "HardwareMediaKeyHandling" }],
-  disableSandbox: [{ flag: "no-sandbox", value: undefined }],
+  // Applied through BrowserWindow's sandbox preference, not a Chromium switch.
+  disableSandbox: [],
   enableWaylandSupport: [
     { flag: "enable-features", value: "UseOzonePlatform" },
     { flag: "ozone-platform-hint", value: "auto" },

--- a/src/features/flags/flags.ts
+++ b/src/features/flags/flags.ts
@@ -9,7 +9,8 @@ import { Logger } from "../logger";
  * Set default Electron flags
  */
 export function setDefaultFlags(app: App) {
-  setFlag(app, "disable-seccomp-filter-sandbox");
+  // Linux zygotes start before our JavaScript. Changing their sandbox switches
+  // here leaves child processes with inconsistent sandbox state.
   setFlag(app, "enable-blink-features", "MiddleClickAutoscroll");
 }
 

--- a/src/pages/settings/settings.html
+++ b/src/pages/settings/settings.html
@@ -631,7 +631,8 @@
               <div class="group__content">
                 <h4>Disable sandbox (Fix white screen login)</h4>
                 <p>
-                  Disables Electron's security sandbox to fix login white screen issues.
+                  Disables the renderer sandbox for the player, settings, and login windows.
+                  Restart the app after changing this setting.
                 </p>
               </div>
               <label class="switch">

--- a/src/scripts/sandbox.ts
+++ b/src/scripts/sandbox.ts
@@ -5,11 +5,9 @@ import { settingsStore } from "./settingsStore";
  * Whether Chromium's renderer sandbox should be turned off.
  *
  * Honours both the explicit `--no-sandbox` command-line switch and the
- * persisted `disableSandbox` flag (which also drives the `--no-sandbox`
- * Chromium switch). Tying the BrowserWindow `sandbox` preference to the same
- * control lets users who hit a blank window (broken /dev/shm, missing setuid
- * sandbox helper, etc.) recover by launching with `--no-sandbox` or toggling
- * the setting.
+ * persisted `disableSandbox` flag. The setting only controls BrowserWindow
+ * preferences; disabling Chromium's sandbox globally requires passing
+ * `--no-sandbox` at launch, before Linux zygotes are initialized.
  */
 export function isSandboxDisabled(): boolean {
   return (


### PR DESCRIPTION
I've hit this on three Arch machines using Wayland, with Niri and Hyprland. With a fresh profile, TIDAL opens a blank player and child processes crash.

On this machine I'm running kernel `7.2.2-arch1-1`, TIDAL Hi-Fi `8.1.3`, and Castlabs Electron `43.0.0+wvcus`. I reproduced it with both AUR packages (`tidal-hifi-bin` and `tidal-hifi-git`) and from source.

TIDAL appends `no-sandbox` and `disable-seccomp-filter-sandbox` after Electron has started its Linux zygotes. This appears to leave processes with inconsistent sandbox state.

This removes those late switches and keeps the saved setting using the existing renderer sandbox preferences. Passing `--no-sandbox` at launch still works. The settings text and troubleshooting docs explain the distinction.

Lint and the package build pass. I tested source and packaged builds with the renderer sandbox setting on and off. After clearing the local profile and caches, the patched build downloaded Widevine and loaded the TIDAL home page without new crashes. Signed-in playback also works. I haven't tested other operating systems.
